### PR TITLE
feat(ui): implement issues #9-#15 with video player error recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,8 +1627,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -2116,7 +2116,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -2656,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "kodama"
 version = "0.1.0"
-source = "git+https://github.com/andymitch/kodama#9944eb769a9eea3c5e79fb3504900e2bad1ec14c"
+source = "git+https://github.com/andymitch/kodama#b2b87947f9c660a63f11fd0d28b81dcd0e1734c7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3302,7 +3302,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.115",
@@ -4027,15 +4027,6 @@ checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
 dependencies = [
  "toml_datetime 0.6.3",
  "toml_edit 0.20.2",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
-dependencies = [
- "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
@@ -5751,18 +5742,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
-dependencies = [
- "indexmap 2.13.0",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "winnow 0.7.14",
-]
-
-[[package]]
 name = "toml_parser"
 version = "1.0.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6992,9 +6971,6 @@ name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winreg"
@@ -7033,8 +7009,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.18",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -366,6 +366,8 @@ mod tests {
     }
 
     mod config_tests {
+        use std::path::PathBuf;
+
         #[test]
         fn default_buffer_capacity_is_512() {
             std::env::remove_var("KODAMA_BUFFER_SIZE");

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -163,7 +163,7 @@ async fn start_embedded_server(ui_path: Option<PathBuf>) -> anyhow::Result<()> {
                                     let mgr = manager.clone();
                                     tokio::spawn(async move {
                                         while let Some(f) = rx.recv().await {
-                                            let mut m = mgr.lock().await;
+                                            let m = mgr.lock().await;
                                             let _ = m.store(&f).await;
                                         }
                                     });

--- a/ui/e2e/app.test.ts
+++ b/ui/e2e/app.test.ts
@@ -56,9 +56,10 @@ test.describe('Settings dialog', () => {
 	test('shows connection status', async ({ page }) => {
 		await page.locator('header').getByRole('button').last().click();
 
-		await expect(page.getByRole('heading', { name: 'Connection' })).toBeVisible();
+		const dialog = page.getByRole('dialog');
+		await expect(dialog.getByRole('heading', { name: 'Connection' })).toBeVisible();
 		// WebSocket mock accepts the upgrade, so transport reports connected
-		await expect(page.getByText('Connected', { exact: true })).toBeVisible();
+		await expect(dialog.getByText('Connected', { exact: true })).toBeVisible();
 	});
 });
 
@@ -67,11 +68,11 @@ test.describe('Header state', () => {
 		const header = page.getByRole('banner');
 		const toggleButtons = header.locator('button[aria-pressed]');
 
-		// Live view: view toggle (2) + grid layout (2) = 4 toggle buttons
-		await expect(toggleButtons).toHaveCount(4);
-
-		// Switch to map: view toggle (2) + marker mode (3) = 5 toggle buttons
-		await page.getByRole('button', { name: /MAP/ }).click();
+		// Live view: view toggle (3: live/map/dashboard) + grid layout (2) = 5 toggle buttons
 		await expect(toggleButtons).toHaveCount(5);
+
+		// Switch to map: view toggle (3) + marker mode (3) = 6 toggle buttons
+		await page.getByRole('button', { name: /MAP/ }).click();
+		await expect(toggleButtons).toHaveCount(6);
 	});
 });

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -7,9 +7,12 @@
 	import SettingsDialog from '$lib/components/layout/SettingsDialog.svelte';
 	import LiveView from '$lib/views/LiveView.svelte';
 	import MapView from '$lib/views/MapView.svelte';
+	import DashboardView from '$lib/views/DashboardView.svelte';
+	import CameraView from '$lib/views/CameraView.svelte';
 
 	let mobileNavOpen = $state(false);
 	let settingsOpen = $state(false);
+	let alertsOpen = $state(false);
 
 	// Apply theme on mount and when it changes
 	$effect(() => {
@@ -34,26 +37,40 @@
 	});
 </script>
 
-<div class="flex h-dvh overflow-hidden bg-background">
-	<!-- Sidebar (desktop only, hidden <768px) -->
-	<Sidebar />
-
-	<!-- Mobile nav sheet -->
-	<MobileNav bind:open={mobileNavOpen} />
-
-	<!-- Main content area -->
-	<div class="flex flex-1 flex-col min-w-0">
-		<Header onMenuClick={() => (mobileNavOpen = true)} onSettingsClick={() => (settingsOpen = true)} />
-
-		<main class="flex-1 overflow-hidden relative">
-			<div class="absolute inset-0" class:hidden={settingsStore.currentView !== 'live'}>
-				<LiveView />
-			</div>
-			<div class="absolute inset-0" class:hidden={settingsStore.currentView !== 'map'}>
-				<MapView />
-			</div>
-		</main>
+{#if settingsStore.currentView === 'camera'}
+	<!-- Camera fullscreen view — no chrome -->
+	<div class="h-dvh overflow-hidden bg-black">
+		<CameraView />
 	</div>
-</div>
+{:else}
+	<div class="flex h-dvh overflow-hidden bg-background">
+		<!-- Sidebar (desktop only, hidden <768px) -->
+		<Sidebar showAlerts={alertsOpen} />
+
+		<!-- Mobile nav sheet -->
+		<MobileNav bind:open={mobileNavOpen} />
+
+		<!-- Main content area -->
+		<div class="flex flex-1 flex-col min-w-0">
+			<Header
+				onMenuClick={() => (mobileNavOpen = true)}
+				onSettingsClick={() => (settingsOpen = true)}
+				onAlertsClick={() => (alertsOpen = !alertsOpen)}
+			/>
+
+			<main class="flex-1 overflow-hidden relative">
+				<div class="absolute inset-0" class:hidden={settingsStore.currentView !== 'live'}>
+					<LiveView />
+				</div>
+				<div class="absolute inset-0" class:hidden={settingsStore.currentView !== 'map'}>
+					<MapView />
+				</div>
+				<div class="absolute inset-0" class:hidden={settingsStore.currentView !== 'dashboard'}>
+					<DashboardView />
+				</div>
+			</main>
+		</div>
+	</div>
+{/if}
 
 <SettingsDialog bind:open={settingsOpen} />

--- a/ui/src/lib/components/VideoPlayer.svelte
+++ b/ui/src/lib/components/VideoPlayer.svelte
@@ -219,7 +219,9 @@
           return;
         }
         console.warn('[VideoPlayer] sourceopen timeout, retrying init for', sourceId, `(attempt ${initRetryCount}/${MAX_INIT_RETRIES})`);
+        const savedRetry = initRetryCount;
         teardown();
+        initRetryCount = savedRetry;
         const retryEvent = pendingInitEvent ?? event;
         pendingInitEvent = null;
         handleInit(retryEvent);

--- a/ui/src/lib/components/VideoPlayer.svelte
+++ b/ui/src/lib/components/VideoPlayer.svelte
@@ -171,6 +171,7 @@
     mediaSegmentsAppended = 0;
     appendErrorCount = 0;
     droppedSegments = 0;
+    initRetryCount = 0;
     if (thumbnailTimer) { clearInterval(thumbnailTimer); thumbnailTimer = null; }
   }
 

--- a/ui/src/lib/components/VideoPlayer.svelte
+++ b/ui/src/lib/components/VideoPlayer.svelte
@@ -268,6 +268,14 @@
     if (!initialized) {
       if (initInProgress) {
         queue.push(event.data);
+      } else if (initRetryCount < MAX_INIT_RETRIES) {
+        // Segments arriving with no init in progress — try recovering from cached init
+        const transport = getTransport();
+        const cachedInit = transport.getVideoInit(sourceId);
+        if (cachedInit) {
+          console.warn('[VideoPlayer] Segment-triggered init recovery for', sourceId);
+          handleInit(cachedInit);
+        }
       }
       return;
     }

--- a/ui/src/lib/components/__tests__/CameraCard.test.ts
+++ b/ui/src/lib/components/__tests__/CameraCard.test.ts
@@ -61,7 +61,7 @@ describe('CameraCard', () => {
 
   it('renders mute toggle (muted by default)', () => {
     render(CameraCard, { props: { sourceId: 'cam1', name: 'Cam', connected: true } });
-    expect(screen.getByText('🔇')).toBeInTheDocument();
+    expect(screen.getByTitle('Select to unmute')).toBeInTheDocument();
   });
 
   it('shows telemetry overlay when camera has telemetry data', () => {

--- a/ui/src/lib/components/alerts/AlertBadge.svelte
+++ b/ui/src/lib/components/alerts/AlertBadge.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import { alertsStore } from '$lib/stores/alerts.svelte.js';
+</script>
+
+{#if alertsStore.unreadCount > 0}
+	<span
+		class="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 text-[10px] font-bold leading-none text-white bg-destructive rounded-full"
+	>
+		{alertsStore.unreadCount > 99 ? '99+' : alertsStore.unreadCount}
+	</span>
+{/if}

--- a/ui/src/lib/components/alerts/AlertPanel.svelte
+++ b/ui/src/lib/components/alerts/AlertPanel.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+	import { alertsStore, type AlertType } from '$lib/stores/alerts.svelte.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { ScrollArea } from '$lib/components/ui/scroll-area/index.js';
+	import { Separator } from '$lib/components/ui/separator/index.js';
+	import { cn } from '$lib/utils.js';
+
+	function alertIcon(type: AlertType): string {
+		switch (type) {
+			case 'motion':
+				return '\u{1F3C3}';
+			case 'disconnect':
+				return '\u{1F534}';
+			case 'reconnect':
+				return '\u{1F7E2}';
+		}
+	}
+
+	function relativeTime(timestamp: number): string {
+		const diff = Math.floor((Date.now() - timestamp) / 1000);
+		if (diff < 5) return 'just now';
+		if (diff < 60) return `${diff}s ago`;
+		const mins = Math.floor(diff / 60);
+		if (mins < 60) return `${mins}m ago`;
+		const hours = Math.floor(mins / 60);
+		if (hours < 24) return `${hours}h ago`;
+		const days = Math.floor(hours / 24);
+		return `${days}d ago`;
+	}
+
+	// Re-compute relative times every 30s
+	let tick = $state(0);
+	$effect(() => {
+		const interval = setInterval(() => {
+			tick++;
+		}, 30_000);
+		return () => clearInterval(interval);
+	});
+
+	// Force reactivity on tick so relativeTime re-evaluates
+	function getAlerts(_tick: number) {
+		return alertsStore.recentAlerts;
+	}
+	let alerts = $derived(getAlerts(tick));
+</script>
+
+<div class="flex flex-col h-full">
+	<!-- Header -->
+	<div class="flex items-center justify-between px-4 py-3">
+		<h2 class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+			Alerts
+			{#if alertsStore.unreadCount > 0}
+				<span class="ml-1.5 text-destructive">{alertsStore.unreadCount}</span>
+			{/if}
+		</h2>
+		<div class="flex items-center gap-1">
+			{#if alertsStore.unreadCount > 0}
+				<Button variant="ghost" size="sm" class="h-6 text-[10px] px-2" onclick={() => alertsStore.markAllRead()}>
+					Mark all read
+				</Button>
+			{/if}
+			{#if alertsStore.recentAlerts.length > 0}
+				<Button variant="ghost" size="sm" class="h-6 text-[10px] px-2 text-destructive hover:text-destructive" onclick={() => alertsStore.clearAll()}>
+					Clear all
+				</Button>
+			{/if}
+		</div>
+	</div>
+
+	<Separator />
+
+	<!-- Alert list -->
+	<ScrollArea class="flex-1 min-h-0">
+		{#if alerts.length === 0}
+			<div class="px-4 py-12 text-xs text-muted-foreground text-center">
+				No alerts
+			</div>
+		{:else}
+			<div class="flex flex-col">
+				{#each alerts as alert (alert.id)}
+					<div
+						class={cn(
+							"flex items-start gap-2.5 px-4 py-2.5 text-left w-full hover:bg-accent/30 transition-colors border-b border-border/50 cursor-pointer",
+							!alert.read && "bg-accent/50"
+						)}
+						role="button"
+						tabindex="0"
+						onclick={() => alertsStore.markRead(alert.id)}
+						onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') alertsStore.markRead(alert.id); }}
+					>
+						<span class="text-sm mt-0.5 shrink-0" role="img" aria-label={alert.type}>
+							{alertIcon(alert.type)}
+						</span>
+						<div class="flex-1 min-w-0">
+							<div class="flex items-center justify-between gap-2">
+								<span class="text-xs font-medium truncate">{alert.cameraName}</span>
+								<span class="text-[10px] text-muted-foreground shrink-0">{relativeTime(alert.timestamp)}</span>
+							</div>
+							<p class="text-[11px] text-muted-foreground mt-0.5 line-clamp-2">{alert.message}</p>
+						</div>
+						<button
+							class="shrink-0 mt-0.5 text-muted-foreground hover:text-foreground text-xs leading-none p-0.5"
+							onclick={(e) => { e.stopPropagation(); alertsStore.dismiss(alert.id); }}
+							aria-label="Dismiss alert"
+						>
+							&#x2715;
+						</button>
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</ScrollArea>
+</div>

--- a/ui/src/lib/components/alerts/AlertPanel.svelte
+++ b/ui/src/lib/components/alerts/AlertPanel.svelte
@@ -39,7 +39,7 @@
 
 	// Force reactivity on tick so relativeTime re-evaluates
 	function getAlerts(_tick: number) {
-		return alertsStore.recentAlerts;
+		return alertsStore.alerts;
 	}
 	let alerts = $derived(getAlerts(tick));
 </script>
@@ -59,7 +59,7 @@
 					Mark all read
 				</Button>
 			{/if}
-			{#if alertsStore.recentAlerts.length > 0}
+			{#if alertsStore.alerts.length > 0}
 				<Button variant="ghost" size="sm" class="h-6 text-[10px] px-2 text-destructive hover:text-destructive" onclick={() => alertsStore.clearAll()}>
 					Clear all
 				</Button>

--- a/ui/src/lib/components/alerts/AlertPanel.svelte
+++ b/ui/src/lib/components/alerts/AlertPanel.svelte
@@ -37,7 +37,8 @@
 		return () => clearInterval(interval);
 	});
 
-	// Force reactivity on tick so relativeTime re-evaluates
+	// _tick is unused inside the function but forces $derived to re-track it,
+	// causing relativeTime values to recompute every 30s
 	function getAlerts(_tick: number) {
 		return alertsStore.alerts;
 	}

--- a/ui/src/lib/components/camera/CameraCard.svelte
+++ b/ui/src/lib/components/camera/CameraCard.svelte
@@ -7,6 +7,7 @@
 	import { videoStatsStore } from '$lib/stores/videoStats.svelte.js';
 	import { cn } from '$lib/utils.js';
 	import { formatBitrateCompact } from '$lib/utils/format.js';
+	import { Camera, PictureInPicture2, Volume2, VolumeOff } from 'lucide-svelte';
 
 	let {
 		sourceId,
@@ -25,7 +26,7 @@
 	let stats = $derived(videoStatsStore.get(sourceId));
 	let muted = $derived(!isSelected);
 	let videoElement = $state<HTMLVideoElement | undefined>(undefined);
-	let cardEl = $state<HTMLButtonElement>(undefined as unknown as HTMLButtonElement);
+	let cardEl = $state<HTMLButtonElement | undefined>(undefined);
 	let isVisible = $state(true);
 
 	// Lazy rendering: pause video decode when card is off-screen
@@ -130,14 +131,18 @@
 	<!-- svelte-ignore a11y_click_events_have_key_events -->
 	<!-- svelte-ignore a11y_no_static_element_interactions -->
 	<div class="absolute bottom-2 right-2 flex items-center gap-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
-		<div class="cursor-pointer rounded bg-black/50 px-1.5 py-0.5" onclick={captureSnapshot} title="Save snapshot">
-			<span class="text-[10px] text-white/70">&#128247;</span>
+		<div class="cursor-pointer rounded bg-black/50 p-1" onclick={captureSnapshot} title="Save snapshot">
+			<Camera class="h-3 w-3 text-white/70" />
 		</div>
-		<div class="cursor-pointer rounded bg-black/50 px-1.5 py-0.5" onclick={togglePiP} title="Picture-in-Picture">
-			<span class="text-[10px] text-white/70">&#128250;</span>
+		<div class="cursor-pointer rounded bg-black/50 p-1" onclick={togglePiP} title="Picture-in-Picture">
+			<PictureInPicture2 class="h-3 w-3 text-white/70" />
 		</div>
-		<div class="rounded bg-black/50 px-1.5 py-0.5" title={muted ? 'Select to unmute' : 'Audio active'}>
-			<span class="text-[10px] text-white/70">{muted ? '🔇' : '🔊'}</span>
+		<div class="rounded bg-black/50 p-1" title={muted ? 'Select to unmute' : 'Audio active'}>
+			{#if muted}
+				<VolumeOff class="h-3 w-3 text-white/70" />
+			{:else}
+				<Volume2 class="h-3 w-3 text-white/70" />
+			{/if}
 		</div>
 	</div>
 

--- a/ui/src/lib/components/camera/CameraCard.svelte
+++ b/ui/src/lib/components/camera/CameraCard.svelte
@@ -6,6 +6,7 @@
 	import { settingsStore } from '$lib/stores/settings.svelte.js';
 	import { videoStatsStore } from '$lib/stores/videoStats.svelte.js';
 	import { cn } from '$lib/utils.js';
+	import { formatBitrateCompact } from '$lib/utils/format.js';
 
 	let {
 		sourceId,
@@ -63,11 +64,6 @@
 		}
 	}
 
-	function formatBitrate(kbps: number): string {
-		if (kbps >= 1000) return `${(kbps / 1000).toFixed(1)}M`;
-		if (kbps > 0) return `${kbps.toFixed(0)}k`;
-		return '';
-	}
 </script>
 
 <button
@@ -99,7 +95,7 @@
 				{#if stats && stats.width > 0}
 					<span class="text-[9px] text-white/50 font-mono">{stats.width}x{stats.height}</span>
 					{#if stats.bitrateKbps > 0}
-						<span class="text-[9px] text-white/50 font-mono">{formatBitrate(stats.bitrateKbps)}</span>
+						<span class="text-[9px] text-white/50 font-mono">{formatBitrateCompact(stats.bitrateKbps)}</span>
 					{/if}
 				{/if}
 				<span class={cn(
@@ -159,7 +155,7 @@
 		<div class="absolute top-8 left-2 z-10 pointer-events-none">
 			<div class="bg-black/70 rounded px-1.5 py-1 text-[9px] font-mono text-green-400 leading-relaxed">
 				<div>{stats.width}x{stats.height} {stats.codec}</div>
-				<div>{formatBitrate(stats.bitrateKbps)}bps</div>
+				<div>{formatBitrateCompact(stats.bitrateKbps)}bps</div>
 				<div>buf {stats.bufferHealth.toFixed(2)}s</div>
 				<div>seg {stats.segmentsAppended}</div>
 				{#if stats.droppedSegments > 0}

--- a/ui/src/lib/components/camera/CameraCard.svelte
+++ b/ui/src/lib/components/camera/CameraCard.svelte
@@ -22,7 +22,7 @@
 	let isSelected = $derived(cameraStore.selectedId === sourceId);
 	let camera = $derived(cameraStore.cameras.find((c) => c.id === sourceId));
 	let stats = $derived(videoStatsStore.get(sourceId));
-	let muted = $state(true);
+	let muted = $derived(!isSelected);
 	let videoElement = $state<HTMLVideoElement | undefined>(undefined);
 	let cardEl = $state<HTMLButtonElement>(undefined as unknown as HTMLButtonElement);
 	let isVisible = $state(true);
@@ -140,14 +140,14 @@
 		<div class="cursor-pointer rounded bg-black/50 px-1.5 py-0.5" onclick={togglePiP} title="Picture-in-Picture">
 			<span class="text-[10px] text-white/70">&#128250;</span>
 		</div>
-		<div class="cursor-pointer rounded bg-black/50 px-1.5 py-0.5" onclick={(e) => { e.stopPropagation(); muted = !muted; }}>
+		<div class="rounded bg-black/50 px-1.5 py-0.5" title={muted ? 'Select to unmute' : 'Audio active'}>
 			<span class="text-[10px] text-white/70">{muted ? '🔇' : '🔊'}</span>
 		</div>
 	</div>
 
 	<!-- Buffer health indicator -->
 	{#if stats && stats.droppedSegments > 0 && !settingsStore.debugMode}
-		<div class="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity">
+		<div class="absolute top-8 right-2 opacity-0 group-hover:opacity-100 transition-opacity">
 			<span class="text-[9px] text-yellow-400/80 font-mono bg-black/50 rounded px-1 py-0.5">
 				{stats.droppedSegments} dropped
 			</span>

--- a/ui/src/lib/components/camera/CameraCard.svelte
+++ b/ui/src/lib/components/camera/CameraCard.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import VideoPlayer from '$lib/components/VideoPlayer.svelte';
 	import AudioPlayer from '$lib/components/AudioPlayer.svelte';
 	import { cameraStore } from '$lib/stores/cameras.svelte.js';
+	import { settingsStore } from '$lib/stores/settings.svelte.js';
+	import { videoStatsStore } from '$lib/stores/videoStats.svelte.js';
 	import { cn } from '$lib/utils.js';
 
 	let {
@@ -18,20 +21,68 @@
 
 	let isSelected = $derived(cameraStore.selectedId === sourceId);
 	let camera = $derived(cameraStore.cameras.find((c) => c.id === sourceId));
+	let stats = $derived(videoStatsStore.get(sourceId));
 	let muted = $state(true);
+	let videoElement = $state<HTMLVideoElement | undefined>(undefined);
+	let cardEl = $state<HTMLButtonElement>(undefined as unknown as HTMLButtonElement);
+	let isVisible = $state(true);
+
+	// Lazy rendering: pause video decode when card is off-screen
+	onMount(() => {
+		if (!cardEl || typeof IntersectionObserver === 'undefined') return;
+		const observer = new IntersectionObserver(
+			([entry]) => { isVisible = entry.isIntersecting; },
+			{ threshold: 0 }
+		);
+		observer.observe(cardEl);
+		return () => observer.disconnect();
+	});
+
+	function captureSnapshot(e: MouseEvent) {
+		e.stopPropagation();
+		if (!videoElement || videoElement.videoWidth === 0) return;
+		const canvas = document.createElement('canvas');
+		canvas.width = videoElement.videoWidth;
+		canvas.height = videoElement.videoHeight;
+		const ctx = canvas.getContext('2d');
+		if (!ctx) return;
+		ctx.drawImage(videoElement, 0, 0);
+		const link = document.createElement('a');
+		link.download = `${name.replace(/[^a-zA-Z0-9]/g, '_')}_${new Date().toISOString().slice(0, 19).replace(/:/g, '-')}.png`;
+		link.href = canvas.toDataURL('image/png');
+		link.click();
+	}
+
+	function togglePiP(e: MouseEvent) {
+		e.stopPropagation();
+		if (!videoElement) return;
+		if (document.pictureInPictureElement === videoElement) {
+			document.exitPictureInPicture().catch(() => {});
+		} else {
+			videoElement.requestPictureInPicture().catch(() => {});
+		}
+	}
+
+	function formatBitrate(kbps: number): string {
+		if (kbps >= 1000) return `${(kbps / 1000).toFixed(1)}M`;
+		if (kbps > 0) return `${kbps.toFixed(0)}k`;
+		return '';
+	}
 </script>
 
 <button
+	bind:this={cardEl}
 	class={cn(
 		"relative overflow-hidden rounded-lg bg-black group cursor-pointer transition-all w-full aspect-video",
 		isSelected ? "ring-2 ring-primary" : "ring-1 ring-border/50 hover:ring-border",
 		featured ? "col-span-2 row-span-2" : ""
 	)}
 	onclick={() => cameraStore.select(sourceId)}
+	ondblclick={() => settingsStore.openCameraView(sourceId)}
 >
 	<!-- Video feed -->
 	<div class="absolute inset-0">
-		<VideoPlayer {sourceId} />
+		<VideoPlayer {sourceId} bind:videoElement active={isVisible} />
 	</div>
 
 	<!-- Top gradient overlay -->
@@ -44,12 +95,20 @@
 				)}></span>
 				<span class="text-xs font-medium text-white/90 drop-shadow-sm">{name}</span>
 			</div>
-			<span class={cn(
-				"text-[10px] uppercase tracking-wider font-semibold px-1.5 py-0.5 rounded",
-				connected ? "bg-primary/20 text-primary" : "bg-destructive/20 text-destructive"
-			)}>
-				{connected ? 'LIVE' : 'OFF'}
-			</span>
+			<div class="flex items-center gap-1.5">
+				{#if stats && stats.width > 0}
+					<span class="text-[9px] text-white/50 font-mono">{stats.width}x{stats.height}</span>
+					{#if stats.bitrateKbps > 0}
+						<span class="text-[9px] text-white/50 font-mono">{formatBitrate(stats.bitrateKbps)}</span>
+					{/if}
+				{/if}
+				<span class={cn(
+					"text-[10px] uppercase tracking-wider font-semibold px-1.5 py-0.5 rounded",
+					connected ? "bg-primary/20 text-primary" : "bg-destructive/20 text-destructive"
+				)}>
+					{connected ? 'LIVE' : 'OFF'}
+				</span>
+			</div>
 		</div>
 	</div>
 
@@ -70,12 +129,46 @@
 
 	<!-- Audio -->
 	<AudioPlayer {sourceId} {muted} />
+
+	<!-- Action buttons (hover) -->
 	<!-- svelte-ignore a11y_click_events_have_key_events -->
 	<!-- svelte-ignore a11y_no_static_element_interactions -->
-	<div
-		class="absolute bottom-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
-		onclick={(e) => { e.stopPropagation(); muted = !muted; }}
-	>
-		<span class="text-xs text-white/70 drop-shadow-sm">{muted ? '🔇' : '🔊'}</span>
+	<div class="absolute bottom-2 right-2 flex items-center gap-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
+		<div class="cursor-pointer rounded bg-black/50 px-1.5 py-0.5" onclick={captureSnapshot} title="Save snapshot">
+			<span class="text-[10px] text-white/70">&#128247;</span>
+		</div>
+		<div class="cursor-pointer rounded bg-black/50 px-1.5 py-0.5" onclick={togglePiP} title="Picture-in-Picture">
+			<span class="text-[10px] text-white/70">&#128250;</span>
+		</div>
+		<div class="cursor-pointer rounded bg-black/50 px-1.5 py-0.5" onclick={(e) => { e.stopPropagation(); muted = !muted; }}>
+			<span class="text-[10px] text-white/70">{muted ? '🔇' : '🔊'}</span>
+		</div>
 	</div>
+
+	<!-- Buffer health indicator -->
+	{#if stats && stats.droppedSegments > 0 && !settingsStore.debugMode}
+		<div class="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity">
+			<span class="text-[9px] text-yellow-400/80 font-mono bg-black/50 rounded px-1 py-0.5">
+				{stats.droppedSegments} dropped
+			</span>
+		</div>
+	{/if}
+
+	<!-- Debug overlay -->
+	{#if settingsStore.debugMode && stats}
+		<div class="absolute top-8 left-2 z-10 pointer-events-none">
+			<div class="bg-black/70 rounded px-1.5 py-1 text-[9px] font-mono text-green-400 leading-relaxed">
+				<div>{stats.width}x{stats.height} {stats.codec}</div>
+				<div>{formatBitrate(stats.bitrateKbps)}bps</div>
+				<div>buf {stats.bufferHealth.toFixed(2)}s</div>
+				<div>seg {stats.segmentsAppended}</div>
+				{#if stats.droppedSegments > 0}
+					<div class="text-yellow-400">drop {stats.droppedSegments}</div>
+				{/if}
+				{#if !isVisible}
+					<div class="text-orange-400">PAUSED</div>
+				{/if}
+			</div>
+		</div>
+	{/if}
 </button>

--- a/ui/src/lib/components/camera/CameraList.svelte
+++ b/ui/src/lib/components/camera/CameraList.svelte
@@ -26,7 +26,7 @@
 	);
 
 	// Active filter applied
-	let filteredCameras = $derived(() => {
+	let filteredCameras = $derived.by(() => {
 		if (cameraConfigStore.activeGroupId === null) return sortedCameras;
 		return sortedCameras.filter(
 			(c) => cameraConfigStore.getGroupId(c.id) === cameraConfigStore.activeGroupId
@@ -93,7 +93,7 @@
 		</div>
 	{/if}
 
-	{#each filteredCameras() as camera (camera.id)}
+	{#each filteredCameras as camera (camera.id)}
 		{@const displayName = cameraConfigStore.getDisplayName(camera.id, camera.name)}
 		<div class="group/item relative">
 			{#if editingId === camera.id}
@@ -194,7 +194,7 @@
 		</div>
 	{/each}
 
-	{#if filteredCameras().length === 0}
+	{#if filteredCameras.length === 0}
 		<div class="px-3 py-8 text-center text-xs text-muted-foreground">
 			{#if cameraConfigStore.activeGroupId}
 				No cameras in this group

--- a/ui/src/lib/components/camera/CameraList.svelte
+++ b/ui/src/lib/components/camera/CameraList.svelte
@@ -166,7 +166,7 @@
 						{#if camera.telemetry}
 							<div class="text-[10px] text-muted-foreground font-mono">
 								CPU {camera.telemetry.cpu_usage.toFixed(0)}%
-								{#if camera.telemetry.memory_usage}
+								{#if camera.telemetry.memory_usage != null}
 									&middot; Mem {camera.telemetry.memory_usage.toFixed(0)}%
 								{/if}
 							</div>

--- a/ui/src/lib/components/camera/CameraList.svelte
+++ b/ui/src/lib/components/camera/CameraList.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import { cameraStore } from '$lib/stores/cameras.svelte.js';
+	import { cameraConfigStore } from '$lib/stores/cameraConfig.svelte.js';
+	import { settingsStore } from '$lib/stores/settings.svelte.js';
 	import { cn } from '$lib/utils.js';
+	import { Pencil, Check, X } from 'lucide-svelte';
 
 	let {
 		onSelect,
@@ -8,66 +11,196 @@
 		onSelect?: () => void;
 	} = $props();
 
-	// Sort: online cameras first, then alphabetical
+	let editingId = $state<string | null>(null);
+	let editingName = $state('');
+	let editingGroupId = $state<string | null>(null);
+
+	// Sort: online cameras first, then alphabetical (using display names)
 	let sortedCameras = $derived(
 		[...cameraStore.cameras].sort((a, b) => {
 			if (a.connected !== b.connected) return a.connected ? -1 : 1;
-			return a.name.localeCompare(b.name);
+			const nameA = cameraConfigStore.getDisplayName(a.id, a.name);
+			const nameB = cameraConfigStore.getDisplayName(b.id, b.name);
+			return nameA.localeCompare(nameB);
 		})
 	);
+
+	// Active filter applied
+	let filteredCameras = $derived(() => {
+		if (cameraConfigStore.activeGroupId === null) return sortedCameras;
+		return sortedCameras.filter(
+			(c) => cameraConfigStore.getGroupId(c.id) === cameraConfigStore.activeGroupId
+		);
+	});
 
 	function selectCamera(id: string) {
 		cameraStore.select(id);
 		onSelect?.();
 	}
+
+	function startEdit(id: string, currentName: string) {
+		editingId = id;
+		editingName = currentName;
+		editingGroupId = cameraConfigStore.getGroupId(id) ?? null;
+	}
+
+	function confirmEdit() {
+		if (editingId) {
+			cameraConfigStore.rename(editingId, editingName);
+			cameraConfigStore.assignGroup(editingId, editingGroupId);
+			editingId = null;
+		}
+	}
+
+	function cancelEdit() {
+		editingId = null;
+	}
+
+	function handleEditKeydown(e: KeyboardEvent) {
+		if (e.key === 'Enter') confirmEdit();
+		else if (e.key === 'Escape') cancelEdit();
+	}
 </script>
 
 <div class="space-y-0.5 py-1">
-	{#each sortedCameras as camera (camera.id)}
-		<button
-			class={cn(
-				"w-full flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-colors text-left",
-				"hover:bg-accent/50",
-				cameraStore.selectedId === camera.id
-					? "bg-accent border-l-2 border-primary"
-					: "border-l-2 border-transparent"
-			)}
-			onclick={() => selectCamera(camera.id)}
-		>
-			<!-- Status dot -->
-			<span
+	{#if cameraConfigStore.groups.length > 0}
+		<!-- Group filter chips -->
+		<div class="flex flex-wrap gap-1 px-3 pb-2">
+			<button
 				class={cn(
-					"h-2 w-2 rounded-full flex-shrink-0",
-					camera.connected ? "bg-primary" : "bg-destructive"
+					"text-[10px] px-2 py-0.5 rounded-full border transition-colors",
+					cameraConfigStore.activeGroupId === null
+						? "bg-primary text-primary-foreground border-primary"
+						: "border-border text-muted-foreground hover:border-foreground/30"
 				)}
-			></span>
+				onclick={() => cameraConfigStore.setFilter(null)}
+			>
+				All
+			</button>
+			{#each cameraConfigStore.groups as group (group.id)}
+				<button
+					class={cn(
+						"text-[10px] px-2 py-0.5 rounded-full border transition-colors",
+						cameraConfigStore.activeGroupId === group.id
+							? "bg-primary text-primary-foreground border-primary"
+							: "border-border text-muted-foreground hover:border-foreground/30"
+					)}
+					onclick={() => cameraConfigStore.setFilter(group.id)}
+				>
+					{group.name}
+				</button>
+			{/each}
+		</div>
+	{/if}
 
-			<!-- Info -->
-			<div class="flex-1 min-w-0">
-				<div class="truncate font-medium">{camera.name}</div>
-				{#if camera.telemetry}
-					<div class="text-[10px] text-muted-foreground font-mono">
-						CPU {camera.telemetry.cpu_usage.toFixed(0)}%
-						{#if camera.telemetry.memory_usage}
-							&middot; Mem {camera.telemetry.memory_usage.toFixed(0)}%
+	{#each filteredCameras() as camera (camera.id)}
+		{@const displayName = cameraConfigStore.getDisplayName(camera.id, camera.name)}
+		<div class="group/item relative">
+			{#if editingId === camera.id}
+				<!-- Inline edit (name + group) -->
+				<div class="px-3 py-2 space-y-1.5">
+					<div class="flex items-center gap-1">
+						<span
+							class={cn(
+								"h-2 w-2 rounded-full flex-shrink-0",
+								camera.connected ? "bg-primary" : "bg-destructive"
+							)}
+						></span>
+						<input
+							type="text"
+							bind:value={editingName}
+							onkeydown={handleEditKeydown}
+							class="flex-1 min-w-0 text-sm bg-transparent border-b border-primary outline-none px-1"
+							autofocus
+						/>
+						<button class="p-0.5 hover:text-primary" onclick={confirmEdit} aria-label="Confirm">
+							<Check class="h-3.5 w-3.5" />
+						</button>
+						<button class="p-0.5 hover:text-destructive" onclick={cancelEdit} aria-label="Cancel">
+							<X class="h-3.5 w-3.5" />
+						</button>
+					</div>
+					{#if cameraConfigStore.groups.length > 0}
+						<select
+							bind:value={editingGroupId}
+							class="w-full text-[10px] px-1.5 py-1 rounded border border-input bg-background text-foreground"
+						>
+							<option value={null}>No group</option>
+							{#each cameraConfigStore.groups as group (group.id)}
+								<option value={group.id}>{group.name}</option>
+							{/each}
+						</select>
+					{/if}
+				</div>
+			{:else}
+				<button
+					class={cn(
+						"w-full flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-colors text-left",
+						"hover:bg-accent/50",
+						cameraStore.selectedId === camera.id
+							? "bg-accent border-l-2 border-primary"
+							: "border-l-2 border-transparent"
+					)}
+					onclick={() => selectCamera(camera.id)}
+					ondblclick={() => settingsStore.openCameraView(camera.id)}
+				>
+					<!-- Status dot -->
+					<span
+						class={cn(
+							"h-2 w-2 rounded-full flex-shrink-0",
+							camera.connected ? "bg-primary" : "bg-destructive"
+						)}
+					></span>
+
+					<!-- Info -->
+					<div class="flex-1 min-w-0">
+						<div class="flex items-center gap-1.5">
+							<span class="truncate font-medium">{displayName}</span>
+							{#if cameraConfigStore.getGroupId(camera.id)}
+								{@const group = cameraConfigStore.groups.find((g) => g.id === cameraConfigStore.getGroupId(camera.id))}
+								{#if group}
+									<span class="text-[9px] px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground shrink-0">{group.name}</span>
+								{/if}
+							{/if}
+						</div>
+						{#if camera.telemetry}
+							<div class="text-[10px] text-muted-foreground font-mono">
+								CPU {camera.telemetry.cpu_usage.toFixed(0)}%
+								{#if camera.telemetry.memory_usage}
+									&middot; Mem {camera.telemetry.memory_usage.toFixed(0)}%
+								{/if}
+							</div>
 						{/if}
 					</div>
-				{/if}
-			</div>
 
-			<!-- Status label -->
-			<span class={cn(
-				"text-[10px] uppercase tracking-wider flex-shrink-0",
-				camera.connected ? "text-primary" : "text-muted-foreground"
-			)}>
-				{camera.connected ? 'Live' : 'Off'}
-			</span>
-		</button>
+					<!-- Status label -->
+					<span class={cn(
+						"text-[10px] uppercase tracking-wider flex-shrink-0",
+						camera.connected ? "text-primary" : "text-muted-foreground"
+					)}>
+						{camera.connected ? 'Live' : 'Off'}
+					</span>
+				</button>
+
+				<!-- Edit button (visible on hover) -->
+				<button
+					class="absolute right-8 top-1/2 -translate-y-1/2 p-1 rounded opacity-0 group-hover/item:opacity-100 hover:bg-accent transition-opacity"
+					onclick={(e) => { e.stopPropagation(); startEdit(camera.id, displayName); }}
+					aria-label="Edit camera"
+				>
+					<Pencil class="h-3 w-3 text-muted-foreground" />
+				</button>
+			{/if}
+		</div>
 	{/each}
 
-	{#if sortedCameras.length === 0}
+	{#if filteredCameras().length === 0}
 		<div class="px-3 py-8 text-center text-xs text-muted-foreground">
-			No cameras connected
+			{#if cameraConfigStore.activeGroupId}
+				No cameras in this group
+			{:else}
+				No cameras connected
+			{/if}
 		</div>
 	{/if}
 </div>

--- a/ui/src/lib/components/camera/CameraList.svelte
+++ b/ui/src/lib/components/camera/CameraList.svelte
@@ -95,6 +95,7 @@
 
 	{#each filteredCameras as camera (camera.id)}
 		{@const displayName = cameraConfigStore.getDisplayName(camera.id, camera.name)}
+		{@const groupId = cameraConfigStore.getGroupId(camera.id)}
 		<div class="group/item relative">
 			{#if editingId === camera.id}
 				<!-- Inline edit (name + group) -->
@@ -156,8 +157,8 @@
 					<div class="flex-1 min-w-0">
 						<div class="flex items-center gap-1.5">
 							<span class="truncate font-medium">{displayName}</span>
-							{#if cameraConfigStore.getGroupId(camera.id)}
-								{@const group = cameraConfigStore.groups.find((g) => g.id === cameraConfigStore.getGroupId(camera.id))}
+							{#if groupId}
+								{@const group = cameraConfigStore.groups.find((g) => g.id === groupId)}
 								{#if group}
 									<span class="text-[9px] px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground shrink-0">{group.name}</span>
 								{/if}

--- a/ui/src/lib/components/layout/Header.svelte
+++ b/ui/src/lib/components/layout/Header.svelte
@@ -4,14 +4,17 @@
 	import { transportStore } from '$lib/stores/transport.svelte.js';
 	import { ToggleGroup, ToggleGroupItem } from '$lib/components/ui/toggle-group/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
-	import { Map, Video, LayoutGrid, LayoutDashboard, Menu, Settings, MapPin, Tag, MonitorPlay } from 'lucide-svelte';
+	import { Map, Video, LayoutGrid, LayoutDashboard, Menu, Settings, MapPin, Tag, MonitorPlay, Bell, Activity } from 'lucide-svelte';
+	import AlertBadge from '$lib/components/alerts/AlertBadge.svelte';
 
 	let {
 		onMenuClick,
 		onSettingsClick,
+		onAlertsClick,
 	}: {
 		onMenuClick?: () => void;
 		onSettingsClick?: () => void;
+		onAlertsClick?: () => void;
 	} = $props();
 
 	let currentView = $derived(settingsStore.currentView);
@@ -32,7 +35,7 @@
 	<div class="flex items-center gap-2">
 		<ToggleGroup bind:value={
 			() => settingsStore.currentView,
-			(v) => settingsStore.setView(v as 'live' | 'map')
+			(v) => settingsStore.setView(v as 'live' | 'map' | 'dashboard')
 		}>
 			<ToggleGroupItem value="live">
 				<Video class="h-4 w-4 mr-1.5" />
@@ -41,6 +44,10 @@
 			<ToggleGroupItem value="map">
 				<Map class="h-4 w-4 mr-1.5" />
 				<span class="hidden sm:inline text-xs">MAP</span>
+			</ToggleGroupItem>
+			<ToggleGroupItem value="dashboard">
+				<Activity class="h-4 w-4 mr-1.5" />
+				<span class="hidden sm:inline text-xs">DASH</span>
 			</ToggleGroupItem>
 		</ToggleGroup>
 	</div>
@@ -82,6 +89,13 @@
 			</span>
 			<span>online</span>
 		</div>
+
+		<Button variant="ghost" size="icon" class="relative" onclick={onAlertsClick}>
+			<Bell class="h-4 w-4" />
+			<span class="absolute -top-0.5 -right-0.5">
+				<AlertBadge />
+			</span>
+		</Button>
 
 		<Button variant="ghost" size="icon" onclick={onSettingsClick}>
 			<Settings class="h-4 w-4" />

--- a/ui/src/lib/components/layout/SettingsDialog.svelte
+++ b/ui/src/lib/components/layout/SettingsDialog.svelte
@@ -5,7 +5,8 @@
 	import { settingsStore } from '$lib/stores/settings.svelte.js';
 	import { transportStore } from '$lib/stores/transport.svelte.js';
 	import type { ServerStatus } from '$lib/types.js';
-	import { Sun, Moon, Monitor } from 'lucide-svelte';
+	import { cameraConfigStore } from '$lib/stores/cameraConfig.svelte.js';
+	import { Sun, Moon, Monitor, Bug, Plus, Trash2 } from 'lucide-svelte';
 
 	let {
 		open = $bindable(false),
@@ -15,6 +16,7 @@
 
 	let status = $state<ServerStatus | null>(null);
 	let statusError = $state(false);
+	let newGroupName = $state('');
 
 	$effect(() => {
 		if (!open) return;
@@ -71,6 +73,58 @@
 
 			<Separator />
 
+			<!-- Camera Groups -->
+			<div>
+				<h3 class="text-sm font-medium mb-3">Camera Groups</h3>
+				<div class="space-y-2">
+					{#each cameraConfigStore.groups as group (group.id)}
+						<div class="flex items-center gap-2">
+							<span class="text-xs flex-1 truncate">{group.name}</span>
+							<button
+								class="p-1 text-muted-foreground hover:text-destructive transition-colors"
+								onclick={() => cameraConfigStore.deleteGroup(group.id)}
+								aria-label="Delete group"
+							>
+								<Trash2 class="h-3.5 w-3.5" />
+							</button>
+						</div>
+					{/each}
+					{#if cameraConfigStore.groups.length === 0}
+						<p class="text-xs text-muted-foreground">No groups created yet</p>
+					{/if}
+					<div class="flex items-center gap-2 mt-2">
+						<input
+							type="text"
+							bind:value={newGroupName}
+							placeholder="New group name..."
+							class="flex-1 text-xs px-2 py-1.5 rounded border border-input bg-background"
+							onkeydown={(e) => {
+								if (e.key === 'Enter' && newGroupName.trim()) {
+									cameraConfigStore.addGroup(newGroupName);
+									newGroupName = '';
+								}
+							}}
+						/>
+						<Button
+							variant="outline"
+							size="sm"
+							disabled={!newGroupName.trim()}
+							onclick={() => {
+								if (newGroupName.trim()) {
+									cameraConfigStore.addGroup(newGroupName);
+									newGroupName = '';
+								}
+							}}
+						>
+							<Plus class="h-3.5 w-3.5" />
+						</Button>
+					</div>
+				</div>
+				<p class="text-xs text-muted-foreground mt-2">Groups let you organize cameras by location. Assign cameras via the sidebar camera list.</p>
+			</div>
+
+			<Separator />
+
 			<!-- Server status -->
 			<div>
 				<h3 class="text-sm font-medium mb-3">Server Status</h3>
@@ -106,6 +160,22 @@
 				{:else}
 					<p class="text-xs text-muted-foreground">Loading server status...</p>
 				{/if}
+			</div>
+
+			<Separator />
+
+			<!-- Debug mode -->
+			<div>
+				<h3 class="text-sm font-medium mb-3">Developer</h3>
+				<Button
+					variant={settingsStore.debugMode ? 'default' : 'outline'}
+					size="sm"
+					onclick={() => (settingsStore.debugMode = !settingsStore.debugMode)}
+				>
+					<Bug class="h-4 w-4 mr-1.5" />
+					Debug Overlay
+				</Button>
+				<p class="text-xs text-muted-foreground mt-1.5">Show video stats on camera cards (codec, bitrate, buffer)</p>
 			</div>
 
 			<Separator />

--- a/ui/src/lib/components/layout/SettingsDialog.svelte
+++ b/ui/src/lib/components/layout/SettingsDialog.svelte
@@ -7,6 +7,7 @@
 	import type { ServerStatus } from '$lib/types.js';
 	import { cameraConfigStore } from '$lib/stores/cameraConfig.svelte.js';
 	import { Sun, Moon, Monitor, Bug, Plus, Trash2 } from 'lucide-svelte';
+	import { formatUptime } from '$lib/utils/format.js';
 
 	let {
 		open = $bindable(false),
@@ -25,11 +26,6 @@
 		transport.getStatus().then((s) => (status = s)).catch(() => { statusError = true; });
 	});
 
-	function formatUptime(secs: number): string {
-		const h = Math.floor(secs / 3600);
-		const m = Math.floor((secs % 3600) / 60);
-		return `${h}h ${m}m`;
-	}
 </script>
 
 <Sheet bind:open>

--- a/ui/src/lib/components/layout/SettingsDialog.svelte
+++ b/ui/src/lib/components/layout/SettingsDialog.svelte
@@ -39,7 +39,7 @@
 			<SheetDescription>Server configuration and preferences</SheetDescription>
 		</SheetHeader>
 
-		<div class="mt-6 space-y-6">
+		<div class="mt-6 space-y-6 overflow-y-auto" style="max-height: calc(100vh - 8rem);">
 			<!-- Theme -->
 			<div>
 				<h3 class="text-sm font-medium mb-3">Theme</h3>

--- a/ui/src/lib/components/layout/Sidebar.svelte
+++ b/ui/src/lib/components/layout/Sidebar.svelte
@@ -5,9 +5,16 @@
 	import { ScrollArea } from '$lib/components/ui/scroll-area/index.js';
 	import CameraList from '$lib/components/camera/CameraList.svelte';
 	import TelemetryPanel from '$lib/components/telemetry/TelemetryPanel.svelte';
+	import AlertPanel from '$lib/components/alerts/AlertPanel.svelte';
 	import { cn } from '$lib/utils.js';
 
-	let { class: className }: { class?: string } = $props();
+	let {
+		class: className,
+		showAlerts = false,
+	}: {
+		class?: string;
+		showAlerts?: boolean;
+	} = $props();
 </script>
 
 <aside
@@ -17,34 +24,38 @@
 	)}
 	style="width: var(--sidebar-width)"
 >
-	<!-- Camera list -->
-	<div class="flex-1 min-h-0">
-		<div class="px-4 py-3">
-			<h2 class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-				Cameras
-				<span class="ml-2 text-primary">{cameraStore.onlineCount}</span>
-			</h2>
-		</div>
-		<ScrollArea class="flex-1 px-2">
-			<CameraList />
-		</ScrollArea>
-	</div>
-
-	<Separator />
-
-	<!-- Telemetry for selected camera -->
-	<div class="flex-shrink-0 overflow-y-auto max-h-[40%]">
-		{#if cameraStore.selected}
+	{#if showAlerts}
+		<AlertPanel />
+	{:else}
+		<!-- Camera list -->
+		<div class="flex-1 min-h-0">
 			<div class="px-4 py-3">
 				<h2 class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-					Telemetry
+					Cameras
+					<span class="ml-2 text-primary">{cameraStore.onlineCount}</span>
 				</h2>
 			</div>
-			<TelemetryPanel sourceId={cameraStore.selected.id} />
-		{:else}
-			<div class="px-4 py-6 text-xs text-muted-foreground text-center">
-				Select a camera to view telemetry
-			</div>
-		{/if}
-	</div>
+			<ScrollArea class="flex-1 px-2">
+				<CameraList />
+			</ScrollArea>
+		</div>
+
+		<Separator />
+
+		<!-- Telemetry for selected camera -->
+		<div class="flex-shrink-0 overflow-y-auto max-h-[40%]">
+			{#if cameraStore.selected}
+				<div class="px-4 py-3">
+					<h2 class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+						Telemetry
+					</h2>
+				</div>
+				<TelemetryPanel sourceId={cameraStore.selected.id} />
+			{:else}
+				<div class="px-4 py-6 text-xs text-muted-foreground text-center">
+					Select a camera to view telemetry
+				</div>
+			{/if}
+		</div>
+	{/if}
 </aside>

--- a/ui/src/lib/components/timeline/RecordingTimeline.svelte
+++ b/ui/src/lib/components/timeline/RecordingTimeline.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import type { RecordingSegment } from '$lib/types.js';
 	import { cn } from '$lib/utils.js';
+	import { Play, Pause, SkipBack, SkipForward, ChevronLeft, ChevronRight, ZoomIn, ZoomOut, Download } from 'lucide-svelte';
+	import { Button } from '$lib/components/ui/button/index.js';
 
 	let {
 		segments = [],
@@ -12,10 +14,14 @@
 
 	let hoverX = $state<number | null>(null);
 	let containerWidth = $state(0);
-	let containerEl: HTMLDivElement;
+	let containerEl = $state<HTMLDivElement>(undefined as unknown as HTMLDivElement);
 
-	// 24-hour window ending now
-	const WINDOW_MS = 24 * 60 * 60 * 1000;
+	// Timeline zoom levels in hours
+	const ZOOM_LEVELS = [1, 4, 8, 12, 24];
+	let zoomIndex = $state(4); // Start at 24h
+	let windowHours = $derived(ZOOM_LEVELS[zoomIndex]);
+	let windowMs = $derived(windowHours * 60 * 60 * 1000);
+
 	let now = $state(Date.now());
 
 	// Update 'now' every minute
@@ -24,7 +30,26 @@
 		return () => clearInterval(interval);
 	});
 
-	let windowStart = $derived(now - WINDOW_MS);
+	// Playback state
+	let playing = $state(false);
+	let playbackTime = $state<number | null>(null);
+	let playbackSpeed = $state(1);
+	const SPEEDS = [0.5, 1, 2, 4];
+
+	// Playback timer
+	$effect(() => {
+		if (!playing || playbackTime === null) return;
+		const interval = setInterval(() => {
+			playbackTime = (playbackTime ?? 0) + 1000 * playbackSpeed;
+			if (playbackTime >= now) {
+				playing = false;
+				playbackTime = null;
+			}
+		}, 1000);
+		return () => clearInterval(interval);
+	});
+
+	let windowStart = $derived(now - windowMs);
 
 	let filteredSegments = $derived(
 		segments.filter((s) => {
@@ -33,19 +58,28 @@
 		})
 	);
 
-	let hours = $derived(
-		Array.from({ length: 25 }, (_, i) => {
-			const t = windowStart + i * (WINDOW_MS / 24);
+	// Generate hour markers based on zoom level
+	let hourMarkers = $derived(() => {
+		const count = windowHours + 1;
+		return Array.from({ length: count }, (_, i) => {
+			const t = windowStart + i * (windowMs / windowHours);
 			return {
-				x: (i / 24) * 100,
+				x: (i / windowHours) * 100,
 				label: new Date(t).getHours().toString().padStart(2, '0'),
 			};
-		})
-	);
+		});
+	});
+
+	// Label interval based on zoom
+	let labelInterval = $derived(() => {
+		if (windowHours <= 4) return 1;
+		if (windowHours <= 12) return 2;
+		return 3;
+	});
 
 	function segmentStyle(seg: RecordingSegment) {
-		const left = Math.max(0, ((seg.start - windowStart) / WINDOW_MS) * 100);
-		const right = Math.min(100, ((seg.end - windowStart) / WINDOW_MS) * 100);
+		const left = Math.max(0, ((seg.start - windowStart) / windowMs) * 100);
+		const right = Math.min(100, ((seg.end - windowStart) / windowMs) * 100);
 		const width = right - left;
 		return `left: ${left}%; width: ${width}%;`;
 	}
@@ -58,10 +92,21 @@
 		}
 	}
 
-	function hoverTime(x: number): string {
-		if (containerWidth === 0) return '';
+	function posToTime(x: number): number {
+		if (containerWidth === 0) return windowStart;
 		const frac = x / containerWidth;
-		const ts = windowStart + frac * WINDOW_MS;
+		return windowStart + frac * windowMs;
+	}
+
+	function timeToPos(t: number): number {
+		return ((t - windowStart) / windowMs) * containerWidth;
+	}
+
+	function formatTime(ts: number): string {
+		return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+	}
+
+	function formatShortTime(ts: number): string {
 		return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 	}
 
@@ -69,71 +114,206 @@
 		const rect = containerEl.getBoundingClientRect();
 		hoverX = e.clientX - rect.left;
 	}
+
+	function handleClick(e: MouseEvent) {
+		const rect = containerEl.getBoundingClientRect();
+		const x = e.clientX - rect.left;
+		const t = posToTime(x);
+		playbackTime = Math.max(windowStart, Math.min(t, now));
+	}
+
+	function togglePlay() {
+		if (playbackTime === null) {
+			playbackTime = now - 60_000; // Start 1 min ago
+		}
+		playing = !playing;
+	}
+
+	function stepFrame(direction: number) {
+		if (playbackTime === null) playbackTime = now - 60_000;
+		playing = false;
+		playbackTime = Math.max(windowStart, Math.min((playbackTime ?? now) + direction * 1000 / 30, now));
+	}
+
+	function skipTime(seconds: number) {
+		if (playbackTime === null) playbackTime = now;
+		playbackTime = Math.max(windowStart, Math.min(playbackTime + seconds * 1000, now));
+	}
+
+	function cycleSpeed() {
+		const idx = SPEEDS.indexOf(playbackSpeed);
+		playbackSpeed = SPEEDS[(idx + 1) % SPEEDS.length];
+	}
+
+	function zoomIn() {
+		if (zoomIndex > 0) zoomIndex--;
+	}
+
+	function zoomOut() {
+		if (zoomIndex < ZOOM_LEVELS.length - 1) zoomIndex++;
+	}
+
+	// Playback position as percentage
+	let playbackPosX = $derived(
+		playbackTime !== null && containerWidth > 0
+			? timeToPos(playbackTime)
+			: null
+	);
+
+	// "Now" marker position
+	let nowPosX = $derived(timeToPos(now));
 </script>
 
-<div class="border-t bg-card px-4 py-2">
-	<div
-		bind:this={containerEl}
-		bind:clientWidth={containerWidth}
-		class="relative h-8 rounded bg-muted overflow-hidden cursor-crosshair"
-		role="slider"
-		tabindex="0"
-		aria-label="Recording timeline"
-		aria-valuemin={0}
-		aria-valuemax={24}
-		aria-valuenow={hoverX !== null && containerWidth > 0 ? Math.round((hoverX / containerWidth) * 24) : 0}
-		onpointermove={handlePointerMove}
-		onpointerleave={() => (hoverX = null)}
-		onkeydown={(e) => {
-			if (!containerWidth) return;
-			const step = containerWidth / 24;
-			if (e.key === 'ArrowRight') {
-				hoverX = Math.min((hoverX ?? 0) + step, containerWidth);
-			} else if (e.key === 'ArrowLeft') {
-				hoverX = Math.max((hoverX ?? 0) - step, 0);
-			}
-		}}
-	>
-		<!-- Segments -->
-		{#each filteredSegments as seg (seg.camera_id + seg.start)}
-			<div
-				class={cn("absolute inset-y-0 rounded-sm", segmentColor(seg.type))}
-				style={segmentStyle(seg)}
-			></div>
-		{/each}
-
-		<!-- Hour markers -->
-		{#each hours as hour}
-			<div
-				class="absolute top-0 bottom-0 w-px bg-border/50"
-				style="left: {hour.x}%"
-			></div>
-		{/each}
-
-		<!-- Hour labels -->
-		<div class="absolute inset-x-0 bottom-0 flex">
-			{#each hours as hour, i}
-				{#if i % 3 === 0}
-					<span
-						class="absolute text-[9px] text-muted-foreground -translate-x-1/2"
-						style="left: {hour.x}%; bottom: 1px"
-					>{hour.label}:00</span>
+<div class="border-t bg-card">
+	<!-- Playback controls bar -->
+	<div class="flex items-center gap-1 px-2 py-1 border-b border-border/50">
+		<!-- Left: playback controls -->
+		<div class="flex items-center gap-0.5">
+			<Button variant="ghost" size="icon" class="h-6 w-6" onclick={() => skipTime(-10)} title="Back 10s">
+				<SkipBack class="h-3 w-3" />
+			</Button>
+			<Button variant="ghost" size="icon" class="h-6 w-6" onclick={() => stepFrame(-1)} title="Previous frame">
+				<ChevronLeft class="h-3 w-3" />
+			</Button>
+			<Button variant="ghost" size="icon" class="h-7 w-7" onclick={togglePlay} title={playing ? 'Pause' : 'Play'}>
+				{#if playing}
+					<Pause class="h-3.5 w-3.5" />
+				{:else}
+					<Play class="h-3.5 w-3.5" />
 				{/if}
-			{/each}
+			</Button>
+			<Button variant="ghost" size="icon" class="h-6 w-6" onclick={() => stepFrame(1)} title="Next frame">
+				<ChevronRight class="h-3 w-3" />
+			</Button>
+			<Button variant="ghost" size="icon" class="h-6 w-6" onclick={() => skipTime(10)} title="Forward 10s">
+				<SkipForward class="h-3 w-3" />
+			</Button>
 		</div>
 
-		<!-- Hover cursor -->
-		{#if hoverX !== null}
-			<div
-				class="absolute top-0 bottom-0 w-px bg-foreground/50 pointer-events-none"
-				style="left: {hoverX}px"
-			></div>
-			<div
-				class="absolute -top-6 text-[10px] bg-popover text-popover-foreground px-1.5 py-0.5 rounded border shadow pointer-events-none -translate-x-1/2"
-				style="left: {hoverX}px"
-			>
-				{hoverTime(hoverX)}
+		<!-- Speed -->
+		<button
+			class="text-[10px] font-mono px-1.5 py-0.5 rounded hover:bg-accent transition-colors"
+			onclick={cycleSpeed}
+			title="Playback speed"
+		>
+			{playbackSpeed}x
+		</button>
+
+		<!-- Playback time display -->
+		<div class="flex-1 text-center">
+			{#if playbackTime !== null}
+				<span class="text-[10px] font-mono text-muted-foreground">{formatTime(playbackTime)}</span>
+			{:else}
+				<span class="text-[10px] text-muted-foreground">Live</span>
+			{/if}
+		</div>
+
+		<!-- Right: zoom + export -->
+		<div class="flex items-center gap-0.5">
+			<Button variant="ghost" size="icon" class="h-6 w-6" onclick={zoomIn} disabled={zoomIndex === 0} title="Zoom in">
+				<ZoomIn class="h-3 w-3" />
+			</Button>
+			<span class="text-[10px] text-muted-foreground font-mono w-6 text-center">{windowHours}h</span>
+			<Button variant="ghost" size="icon" class="h-6 w-6" onclick={zoomOut} disabled={zoomIndex === ZOOM_LEVELS.length - 1} title="Zoom out">
+				<ZoomOut class="h-3 w-3" />
+			</Button>
+			<Button variant="ghost" size="icon" class="h-6 w-6 ml-1" title="Export clip" disabled>
+				<Download class="h-3 w-3" />
+			</Button>
+		</div>
+	</div>
+
+	<!-- Timeline bar -->
+	<div class="px-4 py-2">
+		<!-- svelte-ignore a11y_click_events_have_key_events -->
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<div
+			bind:this={containerEl}
+			bind:clientWidth={containerWidth}
+			class="relative h-8 rounded bg-muted overflow-hidden cursor-crosshair"
+			role="slider"
+			tabindex="0"
+			aria-label="Recording timeline"
+			aria-valuemin={0}
+			aria-valuemax={windowHours}
+			aria-valuenow={hoverX !== null && containerWidth > 0 ? Math.round((hoverX / containerWidth) * windowHours) : 0}
+			onpointermove={handlePointerMove}
+			onpointerleave={() => (hoverX = null)}
+			onclick={handleClick}
+			onkeydown={(e) => {
+				if (!containerWidth) return;
+				const step = containerWidth / windowHours;
+				if (e.key === 'ArrowRight') {
+					hoverX = Math.min((hoverX ?? 0) + step, containerWidth);
+				} else if (e.key === 'ArrowLeft') {
+					hoverX = Math.max((hoverX ?? 0) - step, 0);
+				} else if (e.key === ' ') {
+					e.preventDefault();
+					togglePlay();
+				}
+			}}
+		>
+			<!-- Segments -->
+			{#each filteredSegments as seg (seg.camera_id + seg.start)}
+				<div
+					class={cn("absolute inset-y-0 rounded-sm", segmentColor(seg.type))}
+					style={segmentStyle(seg)}
+				></div>
+			{/each}
+
+			<!-- Hour markers -->
+			{#each hourMarkers() as hour}
+				<div
+					class="absolute top-0 bottom-0 w-px bg-border/50"
+					style="left: {hour.x}%"
+				></div>
+			{/each}
+
+			<!-- Hour labels -->
+			<div class="absolute inset-x-0 bottom-0 flex">
+				{#each hourMarkers() as hour, i}
+					{#if i % labelInterval() === 0}
+						<span
+							class="absolute text-[9px] text-muted-foreground -translate-x-1/2"
+							style="left: {hour.x}%; bottom: 1px"
+						>{hour.label}:00</span>
+					{/if}
+				{/each}
 			</div>
-		{/if}
+
+			<!-- "Now" marker -->
+			{#if nowPosX >= 0 && nowPosX <= containerWidth}
+				<div
+					class="absolute top-0 bottom-0 w-0.5 bg-primary pointer-events-none"
+					style="left: {nowPosX}px"
+				></div>
+			{/if}
+
+			<!-- Playback position marker -->
+			{#if playbackPosX !== null && playbackPosX >= 0 && playbackPosX <= containerWidth}
+				<div
+					class="absolute top-0 bottom-0 w-0.5 bg-yellow-400 pointer-events-none z-10"
+					style="left: {playbackPosX}px"
+				></div>
+				<div
+					class="absolute -top-1 w-2.5 h-2.5 rounded-full bg-yellow-400 border border-background pointer-events-none z-10 -translate-x-1/2"
+					style="left: {playbackPosX}px"
+				></div>
+			{/if}
+
+			<!-- Hover cursor -->
+			{#if hoverX !== null}
+				<div
+					class="absolute top-0 bottom-0 w-px bg-foreground/50 pointer-events-none"
+					style="left: {hoverX}px"
+				></div>
+				<div
+					class="absolute -top-6 text-[10px] bg-popover text-popover-foreground px-1.5 py-0.5 rounded border shadow pointer-events-none -translate-x-1/2"
+					style="left: {hoverX}px"
+				>
+					{formatShortTime(posToTime(hoverX))}
+				</div>
+			{/if}
+		</div>
 	</div>
 </div>

--- a/ui/src/lib/components/timeline/RecordingTimeline.svelte
+++ b/ui/src/lib/components/timeline/RecordingTimeline.svelte
@@ -59,7 +59,7 @@
 	);
 
 	// Generate hour markers based on zoom level
-	let hourMarkers = $derived(() => {
+	let hourMarkers = $derived.by(() => {
 		const count = windowHours + 1;
 		return Array.from({ length: count }, (_, i) => {
 			const t = windowStart + i * (windowMs / windowHours);
@@ -71,7 +71,7 @@
 	});
 
 	// Label interval based on zoom
-	let labelInterval = $derived(() => {
+	let labelInterval = $derived.by(() => {
 		if (windowHours <= 4) return 1;
 		if (windowHours <= 12) return 2;
 		return 3;
@@ -262,7 +262,7 @@
 			{/each}
 
 			<!-- Hour markers -->
-			{#each hourMarkers() as hour}
+			{#each hourMarkers as hour}
 				<div
 					class="absolute top-0 bottom-0 w-px bg-border/50"
 					style="left: {hour.x}%"
@@ -271,8 +271,8 @@
 
 			<!-- Hour labels -->
 			<div class="absolute inset-x-0 bottom-0 flex">
-				{#each hourMarkers() as hour, i}
-					{#if i % labelInterval() === 0}
+				{#each hourMarkers as hour, i}
+					{#if i % labelInterval === 0}
 						<span
 							class="absolute text-[9px] text-muted-foreground -translate-x-1/2"
 							style="left: {hour.x}%; bottom: 1px"

--- a/ui/src/lib/components/ui/Sparkline.svelte
+++ b/ui/src/lib/components/ui/Sparkline.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+
+	let {
+		data = [],
+		width = 120,
+		height = 32,
+		color = 'currentColor',
+		class: className,
+	}: {
+		data?: number[];
+		width?: number;
+		height?: number;
+		color?: string;
+		class?: string;
+	} = $props();
+
+	let points = $derived(() => {
+		if (data.length < 2) return '';
+		const max = Math.max(...data, 1);
+		const step = width / (data.length - 1);
+		return data.map((v, i) => `${i * step},${height - (v / max) * (height - 2) - 1}`).join(' ');
+	});
+
+	let fillPoints = $derived(() => {
+		if (data.length < 2) return '';
+		const max = Math.max(...data, 1);
+		const step = width / (data.length - 1);
+		const line = data.map((v, i) => `${i * step},${height - (v / max) * (height - 2) - 1}`);
+		return `0,${height} ${line.join(' ')} ${width},${height}`;
+	});
+</script>
+
+<svg
+	{width}
+	{height}
+	viewBox="0 0 {width} {height}"
+	class={cn("inline-block", className)}
+	aria-hidden="true"
+>
+	{#if data.length >= 2}
+		<polygon points={fillPoints()} fill={color} opacity="0.1" />
+		<polyline points={points()} fill="none" stroke={color} stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+	{/if}
+</svg>

--- a/ui/src/lib/components/ui/Sparkline.svelte
+++ b/ui/src/lib/components/ui/Sparkline.svelte
@@ -15,14 +15,14 @@
 		class?: string;
 	} = $props();
 
-	let points = $derived(() => {
+	let points = $derived.by(() => {
 		if (data.length < 2) return '';
 		const max = Math.max(...data, 1);
 		const step = width / (data.length - 1);
 		return data.map((v, i) => `${i * step},${height - (v / max) * (height - 2) - 1}`).join(' ');
 	});
 
-	let fillPoints = $derived(() => {
+	let fillPoints = $derived.by(() => {
 		if (data.length < 2) return '';
 		const max = Math.max(...data, 1);
 		const step = width / (data.length - 1);
@@ -39,7 +39,7 @@
 	aria-hidden="true"
 >
 	{#if data.length >= 2}
-		<polygon points={fillPoints()} fill={color} opacity="0.1" />
-		<polyline points={points()} fill="none" stroke={color} stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+		<polygon points={fillPoints} fill={color} opacity="0.1" />
+		<polyline points={points} fill="none" stroke={color} stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
 	{/if}
 </svg>

--- a/ui/src/lib/stores/__tests__/alerts.test.ts
+++ b/ui/src/lib/stores/__tests__/alerts.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { alertsStore } from '../alerts.svelte.js';
+import { flushSync } from 'svelte';
+
+describe('alertsStore', () => {
+	beforeEach(() => {
+		flushSync(() => {
+			alertsStore.clearAll();
+			alertsStore.enabled = true;
+			alertsStore.browserNotifications = false;
+			alertsStore.disconnectAlertEnabled = true;
+			alertsStore.motionThreshold = 0.6;
+		});
+	});
+
+	it('starts with no alerts', () => {
+		expect(alertsStore.alerts).toHaveLength(0);
+		expect(alertsStore.unreadCount).toBe(0);
+	});
+
+	it('adds an alert', () => {
+		flushSync(() => {
+			alertsStore.addAlert('disconnect', 'cam1', 'Front Door', 'Front Door disconnected');
+		});
+		expect(alertsStore.alerts).toHaveLength(1);
+		expect(alertsStore.alerts[0].type).toBe('disconnect');
+		expect(alertsStore.alerts[0].cameraId).toBe('cam1');
+		expect(alertsStore.alerts[0].cameraName).toBe('Front Door');
+		expect(alertsStore.alerts[0].message).toBe('Front Door disconnected');
+		expect(alertsStore.alerts[0].read).toBe(false);
+	});
+
+	it('prepends new alerts (newest first)', () => {
+		flushSync(() => {
+			alertsStore.addAlert('disconnect', 'cam1', 'Cam 1', 'Disconnected');
+			alertsStore.addAlert('motion', 'cam2', 'Cam 2', 'Motion detected');
+		});
+		expect(alertsStore.alerts[0].type).toBe('motion');
+		expect(alertsStore.alerts[1].type).toBe('disconnect');
+	});
+
+	it('tracks unread count', () => {
+		flushSync(() => {
+			alertsStore.addAlert('disconnect', 'cam1', 'Cam 1', 'Disconnected');
+			alertsStore.addAlert('reconnect', 'cam1', 'Cam 1', 'Reconnected');
+		});
+		expect(alertsStore.unreadCount).toBe(2);
+
+		flushSync(() => {
+			alertsStore.markRead(alertsStore.alerts[0].id);
+		});
+		expect(alertsStore.unreadCount).toBe(1);
+	});
+
+	it('marks all read', () => {
+		flushSync(() => {
+			alertsStore.addAlert('disconnect', 'cam1', 'Cam 1', 'Disconnected');
+			alertsStore.addAlert('motion', 'cam2', 'Cam 2', 'Motion');
+			alertsStore.markAllRead();
+		});
+		expect(alertsStore.unreadCount).toBe(0);
+	});
+
+	it('clears all alerts', () => {
+		flushSync(() => {
+			alertsStore.addAlert('disconnect', 'cam1', 'Cam 1', 'Disconnected');
+			alertsStore.addAlert('motion', 'cam2', 'Cam 2', 'Motion');
+			alertsStore.clearAll();
+		});
+		expect(alertsStore.alerts).toHaveLength(0);
+	});
+
+	it('dismisses a single alert', () => {
+		flushSync(() => {
+			alertsStore.addAlert('disconnect', 'cam1', 'Cam 1', 'Disconnected');
+			alertsStore.addAlert('motion', 'cam2', 'Cam 2', 'Motion');
+		});
+		const id = alertsStore.alerts[1].id;
+		flushSync(() => {
+			alertsStore.dismiss(id);
+		});
+		expect(alertsStore.alerts).toHaveLength(1);
+		expect(alertsStore.alerts[0].type).toBe('motion');
+	});
+
+	it('does not add alerts when disabled', () => {
+		flushSync(() => {
+			alertsStore.enabled = false;
+			alertsStore.addAlert('disconnect', 'cam1', 'Cam 1', 'Disconnected');
+		});
+		expect(alertsStore.alerts).toHaveLength(0);
+	});
+
+	it('caps alerts at 100', () => {
+		flushSync(() => {
+			for (let i = 0; i < 110; i++) {
+				alertsStore.addAlert('motion', `cam${i}`, `Cam ${i}`, `Motion ${i}`);
+			}
+		});
+		expect(alertsStore.alerts.length).toBeLessThanOrEqual(100);
+	});
+
+	it('assigns unique incrementing IDs', () => {
+		flushSync(() => {
+			alertsStore.addAlert('disconnect', 'cam1', 'Cam 1', 'D1');
+			alertsStore.addAlert('reconnect', 'cam1', 'Cam 1', 'R1');
+		});
+		const ids = alertsStore.alerts.map((a) => a.id);
+		expect(ids[0]).not.toBe(ids[1]);
+		// Newest first, so first has higher id
+		expect(ids[0]).toBeGreaterThan(ids[1]);
+	});
+});

--- a/ui/src/lib/stores/__tests__/cameraConfig.test.ts
+++ b/ui/src/lib/stores/__tests__/cameraConfig.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { cameraConfigStore } from '../cameraConfig.svelte.js';
+import { flushSync } from 'svelte';
+
+describe('cameraConfigStore', () => {
+	beforeEach(() => {
+		flushSync(() => {
+			// Reset state
+			cameraConfigStore.groups = [];
+			cameraConfigStore.overrides = {};
+			cameraConfigStore.activeGroupId = null;
+		});
+	});
+
+	describe('renaming', () => {
+		it('returns original name when no override', () => {
+			expect(cameraConfigStore.getDisplayName('cam1', 'Original')).toBe('Original');
+		});
+
+		it('returns overridden name', () => {
+			flushSync(() => {
+				cameraConfigStore.rename('cam1', 'My Camera');
+			});
+			expect(cameraConfigStore.getDisplayName('cam1', 'Original')).toBe('My Camera');
+		});
+
+		it('clears override when empty name', () => {
+			flushSync(() => {
+				cameraConfigStore.rename('cam1', 'Custom');
+				cameraConfigStore.rename('cam1', '');
+			});
+			expect(cameraConfigStore.getDisplayName('cam1', 'Original')).toBe('Original');
+		});
+
+		it('trims whitespace', () => {
+			flushSync(() => {
+				cameraConfigStore.rename('cam1', '  Trimmed  ');
+			});
+			expect(cameraConfigStore.getDisplayName('cam1', 'Original')).toBe('Trimmed');
+		});
+	});
+
+	describe('groups', () => {
+		it('starts with no groups', () => {
+			expect(cameraConfigStore.groups).toHaveLength(0);
+		});
+
+		it('adds a group and returns an ID', () => {
+			let id: string = '';
+			flushSync(() => {
+				id = cameraConfigStore.addGroup('Front Yard');
+			});
+			expect(id).toBeTruthy();
+			expect(cameraConfigStore.groups).toHaveLength(1);
+			expect(cameraConfigStore.groups[0].name).toBe('Front Yard');
+		});
+
+		it('deletes a group', () => {
+			let id: string = '';
+			flushSync(() => {
+				id = cameraConfigStore.addGroup('Interior');
+				cameraConfigStore.deleteGroup(id);
+			});
+			expect(cameraConfigStore.groups).toHaveLength(0);
+		});
+
+		it('renames a group', () => {
+			let id: string = '';
+			flushSync(() => {
+				id = cameraConfigStore.addGroup('Old Name');
+				cameraConfigStore.renameGroup(id, 'New Name');
+			});
+			expect(cameraConfigStore.groups[0].name).toBe('New Name');
+		});
+
+		it('assigns camera to group', () => {
+			let groupId: string = '';
+			flushSync(() => {
+				groupId = cameraConfigStore.addGroup('Outdoor');
+				cameraConfigStore.assignGroup('cam1', groupId);
+			});
+			expect(cameraConfigStore.getGroupId('cam1')).toBe(groupId);
+		});
+
+		it('unassigns camera from group', () => {
+			let groupId: string = '';
+			flushSync(() => {
+				groupId = cameraConfigStore.addGroup('Outdoor');
+				cameraConfigStore.assignGroup('cam1', groupId);
+				cameraConfigStore.assignGroup('cam1', null);
+			});
+			expect(cameraConfigStore.getGroupId('cam1')).toBeUndefined();
+		});
+
+		it('unassigns cameras when group is deleted', () => {
+			let groupId: string = '';
+			flushSync(() => {
+				groupId = cameraConfigStore.addGroup('Outdoor');
+				cameraConfigStore.assignGroup('cam1', groupId);
+				cameraConfigStore.assignGroup('cam2', groupId);
+				cameraConfigStore.deleteGroup(groupId);
+			});
+			expect(cameraConfigStore.getGroupId('cam1')).toBeUndefined();
+			expect(cameraConfigStore.getGroupId('cam2')).toBeUndefined();
+		});
+
+		it('clears active filter when filtered group is deleted', () => {
+			let groupId: string = '';
+			flushSync(() => {
+				groupId = cameraConfigStore.addGroup('ToDelete');
+				cameraConfigStore.setFilter(groupId);
+				cameraConfigStore.deleteGroup(groupId);
+			});
+			expect(cameraConfigStore.activeGroupId).toBeNull();
+		});
+	});
+
+	describe('filtering', () => {
+		it('starts with no active filter', () => {
+			expect(cameraConfigStore.activeGroupId).toBeNull();
+		});
+
+		it('sets active group filter', () => {
+			let groupId: string = '';
+			flushSync(() => {
+				groupId = cameraConfigStore.addGroup('Test');
+				cameraConfigStore.setFilter(groupId);
+			});
+			expect(cameraConfigStore.activeGroupId).toBe(groupId);
+		});
+
+		it('clears filter', () => {
+			flushSync(() => {
+				cameraConfigStore.setFilter(null);
+			});
+			expect(cameraConfigStore.activeGroupId).toBeNull();
+		});
+	});
+});

--- a/ui/src/lib/stores/alerts.svelte.ts
+++ b/ui/src/lib/stores/alerts.svelte.ts
@@ -23,8 +23,6 @@ class AlertsStore {
 
 	unreadCount = $derived(this.alerts.filter((a) => !a.read).length);
 
-	recentAlerts = $derived(this.alerts.slice(0, MAX_ALERTS));
-
 	addAlert(type: AlertType, cameraId: string, cameraName: string, message: string) {
 		if (!this.enabled) return;
 

--- a/ui/src/lib/stores/alerts.svelte.ts
+++ b/ui/src/lib/stores/alerts.svelte.ts
@@ -1,0 +1,74 @@
+export type AlertType = 'motion' | 'disconnect' | 'reconnect';
+
+export interface Alert {
+	id: number;
+	type: AlertType;
+	cameraId: string;
+	cameraName: string;
+	message: string;
+	timestamp: number;
+	read: boolean;
+}
+
+const MAX_ALERTS = 100;
+
+class AlertsStore {
+	alerts = $state<Alert[]>([]);
+	enabled = $state(true);
+	browserNotifications = $state(false);
+	motionThreshold = $state(0.6);
+	disconnectAlertEnabled = $state(true);
+
+	private nextId = 1;
+
+	unreadCount = $derived(this.alerts.filter((a) => !a.read).length);
+
+	recentAlerts = $derived(this.alerts.slice(0, MAX_ALERTS));
+
+	addAlert(type: AlertType, cameraId: string, cameraName: string, message: string) {
+		if (!this.enabled) return;
+
+		const alert: Alert = {
+			id: this.nextId++,
+			type,
+			cameraId,
+			cameraName,
+			message,
+			timestamp: Date.now(),
+			read: false,
+		};
+
+		// Prepend new alert and cap at MAX_ALERTS
+		this.alerts = [alert, ...this.alerts].slice(0, MAX_ALERTS);
+
+		// Browser notification
+		if (this.browserNotifications && typeof window !== 'undefined' && 'Notification' in window) {
+			if (Notification.permission === 'granted') {
+				new Notification(`${cameraName} - ${type}`, { body: message });
+			}
+		}
+	}
+
+	markRead(id: number) {
+		const idx = this.alerts.findIndex((a) => a.id === id);
+		if (idx >= 0) {
+			this.alerts[idx].read = true;
+		}
+	}
+
+	markAllRead() {
+		for (const alert of this.alerts) {
+			alert.read = true;
+		}
+	}
+
+	clearAll() {
+		this.alerts = [];
+	}
+
+	dismiss(id: number) {
+		this.alerts = this.alerts.filter((a) => a.id !== id);
+	}
+}
+
+export const alertsStore = new AlertsStore();

--- a/ui/src/lib/stores/cameraConfig.svelte.ts
+++ b/ui/src/lib/stores/cameraConfig.svelte.ts
@@ -43,7 +43,7 @@ class CameraConfigStore {
 
 	/** Get display name for a camera (override or fallback to original) */
 	getDisplayName(cameraId: string, originalName: string): string {
-		return this.overrides[cameraId]?.displayName || originalName;
+		return this.overrides[cameraId]?.displayName ?? originalName;
 	}
 
 	/** Rename a camera */

--- a/ui/src/lib/stores/cameraConfig.svelte.ts
+++ b/ui/src/lib/stores/cameraConfig.svelte.ts
@@ -50,7 +50,7 @@ class CameraConfigStore {
 	rename(cameraId: string, name: string) {
 		const trimmed = name.trim();
 		const current = this.overrides[cameraId] ?? {};
-		if (!trimmed || trimmed === '') {
+		if (!trimmed) {
 			// Clear override if empty
 			delete current.displayName;
 		} else {

--- a/ui/src/lib/stores/cameraConfig.svelte.ts
+++ b/ui/src/lib/stores/cameraConfig.svelte.ts
@@ -1,0 +1,115 @@
+/** Client-side camera configuration (names, groups). Persisted to localStorage. */
+
+export interface CameraGroup {
+	id: string;
+	name: string;
+}
+
+export interface CameraOverrides {
+	/** User-assigned display name (overrides server-provided name) */
+	displayName?: string;
+	/** Group ID this camera belongs to */
+	groupId?: string;
+}
+
+const STORAGE_KEY = 'kodama-camera-config';
+
+class CameraConfigStore {
+	groups = $state<CameraGroup[]>([]);
+	overrides = $state<Record<string, CameraOverrides>>({});
+	/** Currently active group filter (null = show all) */
+	activeGroupId = $state<string | null>(null);
+
+	constructor() {
+		if (typeof window !== 'undefined') {
+			try {
+				const raw = localStorage.getItem(STORAGE_KEY);
+				if (raw) {
+					const data = JSON.parse(raw);
+					if (data.groups) this.groups = data.groups;
+					if (data.overrides) this.overrides = data.overrides;
+				}
+			} catch {}
+		}
+	}
+
+	private persist() {
+		if (typeof window === 'undefined') return;
+		localStorage.setItem(
+			STORAGE_KEY,
+			JSON.stringify({ groups: this.groups, overrides: this.overrides })
+		);
+	}
+
+	/** Get display name for a camera (override or fallback to original) */
+	getDisplayName(cameraId: string, originalName: string): string {
+		return this.overrides[cameraId]?.displayName || originalName;
+	}
+
+	/** Rename a camera */
+	rename(cameraId: string, name: string) {
+		const trimmed = name.trim();
+		const current = this.overrides[cameraId] ?? {};
+		if (!trimmed || trimmed === '') {
+			// Clear override if empty
+			delete current.displayName;
+		} else {
+			current.displayName = trimmed;
+		}
+		this.overrides = { ...this.overrides, [cameraId]: current };
+		this.persist();
+	}
+
+	/** Assign a camera to a group (null to unassign) */
+	assignGroup(cameraId: string, groupId: string | null) {
+		const current = this.overrides[cameraId] ?? {};
+		if (groupId) {
+			current.groupId = groupId;
+		} else {
+			delete current.groupId;
+		}
+		this.overrides = { ...this.overrides, [cameraId]: current };
+		this.persist();
+	}
+
+	/** Get group ID for a camera */
+	getGroupId(cameraId: string): string | undefined {
+		return this.overrides[cameraId]?.groupId;
+	}
+
+	/** Create a new group */
+	addGroup(name: string): string {
+		const id = `grp_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+		this.groups = [...this.groups, { id, name: name.trim() }];
+		this.persist();
+		return id;
+	}
+
+	/** Rename a group */
+	renameGroup(groupId: string, name: string) {
+		this.groups = this.groups.map((g) => (g.id === groupId ? { ...g, name: name.trim() } : g));
+		this.persist();
+	}
+
+	/** Delete a group and unassign all cameras from it */
+	deleteGroup(groupId: string) {
+		this.groups = this.groups.filter((g) => g.id !== groupId);
+		const next = { ...this.overrides };
+		for (const [camId, ov] of Object.entries(next)) {
+			if (ov.groupId === groupId) {
+				delete ov.groupId;
+				next[camId] = { ...ov };
+			}
+		}
+		this.overrides = next;
+		if (this.activeGroupId === groupId) this.activeGroupId = null;
+		this.persist();
+	}
+
+	/** Set active group filter */
+	setFilter(groupId: string | null) {
+		this.activeGroupId = groupId;
+	}
+}
+
+export const cameraConfigStore = new CameraConfigStore();

--- a/ui/src/lib/stores/settings.svelte.ts
+++ b/ui/src/lib/stores/settings.svelte.ts
@@ -6,6 +6,10 @@ class SettingsStore {
 	markerMode = $state<MarkerMode>('detailed');
 	sidebarOpen = $state(true);
 	currentView = $state<ViewMode>('live');
+	/** Camera ID for the single-camera fullscreen view */
+	focusedCameraId = $state<string | null>(null);
+	/** Show debug stats overlay on camera cards */
+	debugMode = $state(false);
 
 	constructor() {
 		if (typeof window !== 'undefined') {
@@ -58,6 +62,19 @@ class SettingsStore {
 
 	setView(view: ViewMode) {
 		this.currentView = view;
+		if (view !== 'camera') {
+			this.focusedCameraId = null;
+		}
+	}
+
+	openCameraView(cameraId: string) {
+		this.focusedCameraId = cameraId;
+		this.currentView = 'camera';
+	}
+
+	closeCameraView() {
+		this.focusedCameraId = null;
+		this.currentView = 'live';
 	}
 
 	toggleSidebar() {

--- a/ui/src/lib/stores/transport.svelte.ts
+++ b/ui/src/lib/stores/transport.svelte.ts
@@ -1,6 +1,7 @@
 import { getTransport } from '$lib/transport-ws.js';
 import type { KodamaTransport } from '$lib/transport.js';
 import { cameraStore } from './cameras.svelte.js';
+import { cameraConfigStore } from './cameraConfig.svelte.js';
 import { alertsStore } from './alerts.svelte.js';
 
 class TransportStore {
@@ -26,7 +27,7 @@ class TransportStore {
 			this.unsubs.push(
 				this.transport.on('camera-event', (ev) => {
 					const cam = cameraStore.cameras.find((c) => c.id === ev.source_id);
-					const name = cam?.name ?? ev.source_id;
+					const name = cameraConfigStore.getDisplayName(ev.source_id, cam?.name ?? ev.source_id);
 					const wasPreviouslyConnected = cam?.connected ?? false;
 
 					cameraStore.updateCamera(ev.source_id, ev.connected);
@@ -50,7 +51,7 @@ class TransportStore {
 						if (now - last > 30_000) {
 							this.lastMotionAlert.set(ev.source_id, now);
 							const cam = cameraStore.cameras.find((c) => c.id === ev.source_id);
-							const name = cam?.name ?? ev.source_id;
+							const name = cameraConfigStore.getDisplayName(ev.source_id, cam?.name ?? ev.source_id);
 							alertsStore.addAlert('motion', ev.source_id, name, `Motion detected (${(ev.motion_level * 100).toFixed(0)}%)`);
 						}
 					}

--- a/ui/src/lib/stores/transport.svelte.ts
+++ b/ui/src/lib/stores/transport.svelte.ts
@@ -1,6 +1,7 @@
 import { getTransport } from '$lib/transport-ws.js';
 import type { KodamaTransport } from '$lib/transport.js';
 import { cameraStore } from './cameras.svelte.js';
+import { alertsStore } from './alerts.svelte.js';
 
 class TransportStore {
 	connected = $state(false);
@@ -8,6 +9,8 @@ class TransportStore {
 
 	private transport: KodamaTransport;
 	private unsubs: (() => void)[] = [];
+	/** Track last motion alert per camera to avoid spamming */
+	private lastMotionAlert = new Map<string, number>();
 
 	constructor() {
 		this.transport = getTransport();
@@ -22,10 +25,35 @@ class TransportStore {
 			// Wire up event routing to stores
 			this.unsubs.push(
 				this.transport.on('camera-event', (ev) => {
+					const cam = cameraStore.cameras.find((c) => c.id === ev.source_id);
+					const name = cam?.name ?? ev.source_id;
+					const wasPreviouslyConnected = cam?.connected ?? false;
+
 					cameraStore.updateCamera(ev.source_id, ev.connected);
+
+					// Fire disconnect/reconnect alerts
+					if (alertsStore.disconnectAlertEnabled) {
+						if (!ev.connected && wasPreviouslyConnected) {
+							alertsStore.addAlert('disconnect', ev.source_id, name, `${name} disconnected`);
+						} else if (ev.connected && !wasPreviouslyConnected && cam) {
+							alertsStore.addAlert('reconnect', ev.source_id, name, `${name} reconnected`);
+						}
+					}
 				}),
 				this.transport.on('telemetry', (ev) => {
 					cameraStore.updateTelemetry(ev);
+
+					// Fire motion alert if threshold exceeded (max once per 30s per camera)
+					if (ev.motion_level !== null && ev.motion_level >= alertsStore.motionThreshold) {
+						const now = Date.now();
+						const last = this.lastMotionAlert.get(ev.source_id) ?? 0;
+						if (now - last > 30_000) {
+							this.lastMotionAlert.set(ev.source_id, now);
+							const cam = cameraStore.cameras.find((c) => c.id === ev.source_id);
+							const name = cam?.name ?? ev.source_id;
+							alertsStore.addAlert('motion', ev.source_id, name, `Motion detected (${(ev.motion_level * 100).toFixed(0)}%)`);
+						}
+					}
 				})
 			);
 

--- a/ui/src/lib/stores/videoStats.svelte.ts
+++ b/ui/src/lib/stores/videoStats.svelte.ts
@@ -1,0 +1,34 @@
+/** Per-source video statistics for quality indicators */
+
+export interface VideoStats {
+	width: number;
+	height: number;
+	codec: string;
+	segmentsAppended: number;
+	droppedSegments: number;
+	bufferHealth: number; // seconds of buffered data ahead of current time
+	/** Estimated bitrate in kbps (based on recent segment sizes) */
+	bitrateKbps: number;
+}
+
+class VideoStatsStore {
+	private stats = $state<Map<string, VideoStats>>(new Map());
+
+	get(sourceId: string): VideoStats | undefined {
+		return this.stats.get(sourceId);
+	}
+
+	update(sourceId: string, stats: VideoStats) {
+		const next = new Map(this.stats);
+		next.set(sourceId, stats);
+		this.stats = next;
+	}
+
+	remove(sourceId: string) {
+		const next = new Map(this.stats);
+		next.delete(sourceId);
+		this.stats = next;
+	}
+}
+
+export const videoStatsStore = new VideoStatsStore();

--- a/ui/src/lib/transport-ws.ts
+++ b/ui/src/lib/transport-ws.ts
@@ -144,6 +144,10 @@ export class WebSocketTransport implements KodamaTransport {
     return () => set.delete(cb as Listener<any>);
   }
 
+  getVideoInit(sourceId: string): VideoInitEvent | undefined {
+    return this.videoInitCache.get(sourceId);
+  }
+
   async listCameras(): Promise<CameraInfo[]> {
     const res = await fetch(`${this.baseUrl}/api/cameras`);
     if (!res.ok) throw new Error(`Failed to list cameras: ${res.status}`);

--- a/ui/src/lib/transport.ts
+++ b/ui/src/lib/transport.ts
@@ -41,6 +41,8 @@ export interface KodamaTransport {
     cb: (data: TransportEvents[E]) => void,
   ): Unsubscribe;
 
+  getVideoInit(sourceId: string): VideoInitEvent | undefined;
+
   listCameras(): Promise<CameraInfo[]>;
   getStatus(): Promise<ServerStatus>;
 }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -73,4 +73,4 @@ export interface RecordingSegment {
 
 export type GridLayout = 'auto' | '1+5';
 export type MarkerMode = 'dot' | 'detailed' | 'pip';
-export type ViewMode = 'live' | 'map';
+export type ViewMode = 'live' | 'map' | 'dashboard' | 'camera';

--- a/ui/src/lib/utils/format.ts
+++ b/ui/src/lib/utils/format.ts
@@ -1,0 +1,22 @@
+/** Format a bitrate in kbps to a human-readable string */
+export function formatBitrate(kbps: number): string {
+	if (kbps >= 1000) return `${(kbps / 1000).toFixed(1)} Mbps`;
+	if (kbps > 0) return `${kbps.toFixed(0)} kbps`;
+	return '0 kbps';
+}
+
+/** Compact bitrate format for overlays (e.g. "1.2M", "45k") */
+export function formatBitrateCompact(kbps: number): string {
+	if (kbps >= 1000) return `${(kbps / 1000).toFixed(1)}M`;
+	if (kbps > 0) return `${kbps.toFixed(0)}k`;
+	return '';
+}
+
+/** Format seconds of uptime to a human-readable string */
+export function formatUptime(secs: number): string {
+	const d = Math.floor(secs / 86400);
+	const h = Math.floor((secs % 86400) / 3600);
+	const m = Math.floor((secs % 3600) / 60);
+	if (d > 0) return `${d}d ${h}h ${m}m`;
+	return `${h}h ${m}m`;
+}

--- a/ui/src/lib/views/CameraView.svelte
+++ b/ui/src/lib/views/CameraView.svelte
@@ -20,7 +20,7 @@
 	let showOverlay = $state(true);
 	let overlayTimer: ReturnType<typeof setTimeout> | null = null;
 	let isFullscreen = $state(false);
-	let containerEl = $state<HTMLDivElement>(undefined as unknown as HTMLDivElement);
+	let containerEl = $state<HTMLDivElement | undefined>(undefined);
 	let videoElement = $state<HTMLVideoElement | undefined>(undefined);
 
 	function goBack() {

--- a/ui/src/lib/views/CameraView.svelte
+++ b/ui/src/lib/views/CameraView.svelte
@@ -9,6 +9,7 @@
 	import { videoStatsStore } from '$lib/stores/videoStats.svelte.js';
 	import { ArrowLeft, Maximize, Minimize, Volume2, VolumeOff, Camera, PictureInPicture2 } from 'lucide-svelte';
 	import { cn } from '$lib/utils.js';
+	import { formatBitrate, formatUptime } from '$lib/utils/format.js';
 
 	let cameraId = $derived(settingsStore.focusedCameraId);
 	let camera = $derived(cameraId ? cameraStore.cameras.find((c) => c.id === cameraId) : null);
@@ -99,12 +100,6 @@
 		}
 	}
 
-	function formatBitrate(kbps: number): string {
-		if (kbps >= 1000) return `${(kbps / 1000).toFixed(1)} Mbps`;
-		if (kbps > 0) return `${kbps.toFixed(0)} kbps`;
-		return '';
-	}
-
 	// Auto-hide overlay on mount
 	$effect(() => {
 		resetOverlayTimer();
@@ -113,15 +108,6 @@
 		};
 	});
 
-	function formatUptime(secs: number): string {
-		const h = Math.floor(secs / 3600);
-		const m = Math.floor((secs % 3600) / 60);
-		if (h > 24) {
-			const d = Math.floor(h / 24);
-			return `${d}d ${h % 24}h`;
-		}
-		return `${h}h ${m}m`;
-	}
 </script>
 
 {#if cameraId && camera}

--- a/ui/src/lib/views/CameraView.svelte
+++ b/ui/src/lib/views/CameraView.svelte
@@ -15,7 +15,7 @@
 	let displayName = $derived(camera ? cameraConfigStore.getDisplayName(camera.id, camera.name) : '');
 	let stats = $derived(cameraId ? videoStatsStore.get(cameraId) : undefined);
 
-	let muted = $state(true);
+	let muted = $state(false);
 	let showOverlay = $state(true);
 	let overlayTimer: ReturnType<typeof setTimeout> | null = null;
 	let isFullscreen = $state(false);

--- a/ui/src/lib/views/CameraView.svelte
+++ b/ui/src/lib/views/CameraView.svelte
@@ -1,0 +1,247 @@
+<script lang="ts">
+	import { settingsStore } from '$lib/stores/settings.svelte.js';
+	import { cameraStore } from '$lib/stores/cameras.svelte.js';
+	import { cameraConfigStore } from '$lib/stores/cameraConfig.svelte.js';
+	import VideoPlayer from '$lib/components/VideoPlayer.svelte';
+	import AudioPlayer from '$lib/components/AudioPlayer.svelte';
+	import AudioMeter from '$lib/components/AudioMeter.svelte';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { videoStatsStore } from '$lib/stores/videoStats.svelte.js';
+	import { ArrowLeft, Maximize, Minimize, Volume2, VolumeOff, Camera, PictureInPicture2 } from 'lucide-svelte';
+	import { cn } from '$lib/utils.js';
+
+	let cameraId = $derived(settingsStore.focusedCameraId);
+	let camera = $derived(cameraId ? cameraStore.cameras.find((c) => c.id === cameraId) : null);
+	let displayName = $derived(camera ? cameraConfigStore.getDisplayName(camera.id, camera.name) : '');
+	let stats = $derived(cameraId ? videoStatsStore.get(cameraId) : undefined);
+
+	let muted = $state(true);
+	let showOverlay = $state(true);
+	let overlayTimer: ReturnType<typeof setTimeout> | null = null;
+	let isFullscreen = $state(false);
+	let containerEl = $state<HTMLDivElement>(undefined as unknown as HTMLDivElement);
+	let videoElement = $state<HTMLVideoElement | undefined>(undefined);
+
+	function goBack() {
+		settingsStore.closeCameraView();
+	}
+
+	function resetOverlayTimer() {
+		showOverlay = true;
+		if (overlayTimer) clearTimeout(overlayTimer);
+		overlayTimer = setTimeout(() => {
+			showOverlay = false;
+		}, 3000);
+	}
+
+	function toggleFullscreen() {
+		if (!containerEl) return;
+		if (document.fullscreenElement) {
+			document.exitFullscreen();
+		} else {
+			containerEl.requestFullscreen();
+		}
+	}
+
+	$effect(() => {
+		function onFullscreenChange() {
+			isFullscreen = !!document.fullscreenElement;
+		}
+		document.addEventListener('fullscreenchange', onFullscreenChange);
+		return () => document.removeEventListener('fullscreenchange', onFullscreenChange);
+	});
+
+	// Keyboard shortcuts
+	$effect(() => {
+		function onKeyDown(e: KeyboardEvent) {
+			if (settingsStore.currentView !== 'camera') return;
+			if (e.key === 'Escape') {
+				if (isFullscreen) {
+					document.exitFullscreen();
+				} else {
+					goBack();
+				}
+			} else if (e.key === 'f' || e.key === 'F') {
+				toggleFullscreen();
+			} else if (e.key === 'm' || e.key === 'M') {
+				muted = !muted;
+			} else if (e.key === 's' || e.key === 'S') {
+				captureSnapshot();
+			} else if (e.key === 'p' || e.key === 'P') {
+				togglePiP();
+			}
+		}
+		window.addEventListener('keydown', onKeyDown);
+		return () => window.removeEventListener('keydown', onKeyDown);
+	});
+
+	function captureSnapshot() {
+		if (!videoElement || videoElement.videoWidth === 0) return;
+		const canvas = document.createElement('canvas');
+		canvas.width = videoElement.videoWidth;
+		canvas.height = videoElement.videoHeight;
+		const ctx = canvas.getContext('2d');
+		if (!ctx) return;
+		ctx.drawImage(videoElement, 0, 0);
+		const link = document.createElement('a');
+		const cameraName = displayName || 'camera';
+		link.download = `${cameraName.replace(/[^a-zA-Z0-9]/g, '_')}_${new Date().toISOString().slice(0, 19).replace(/:/g, '-')}.png`;
+		link.href = canvas.toDataURL('image/png');
+		link.click();
+	}
+
+	function togglePiP() {
+		if (!videoElement) return;
+		if (document.pictureInPictureElement === videoElement) {
+			document.exitPictureInPicture().catch(() => {});
+		} else {
+			videoElement.requestPictureInPicture().catch(() => {});
+		}
+	}
+
+	function formatBitrate(kbps: number): string {
+		if (kbps >= 1000) return `${(kbps / 1000).toFixed(1)} Mbps`;
+		if (kbps > 0) return `${kbps.toFixed(0)} kbps`;
+		return '';
+	}
+
+	// Auto-hide overlay on mount
+	$effect(() => {
+		resetOverlayTimer();
+		return () => {
+			if (overlayTimer) clearTimeout(overlayTimer);
+		};
+	});
+
+	function formatUptime(secs: number): string {
+		const h = Math.floor(secs / 3600);
+		const m = Math.floor((secs % 3600) / 60);
+		if (h > 24) {
+			const d = Math.floor(h / 24);
+			return `${d}d ${h % 24}h`;
+		}
+		return `${h}h ${m}m`;
+	}
+</script>
+
+{#if cameraId && camera}
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<div
+		bind:this={containerEl}
+		class="relative h-full w-full bg-black overflow-hidden"
+		onpointermove={resetOverlayTimer}
+		onclick={resetOverlayTimer}
+	>
+		<!-- Video (full area) -->
+		<div class="absolute inset-0">
+			<VideoPlayer sourceId={cameraId} bind:videoElement />
+		</div>
+
+		<!-- Audio -->
+		<AudioPlayer sourceId={cameraId} {muted} />
+
+		<!-- Top overlay -->
+		<div
+			class={cn(
+				"absolute inset-x-0 top-0 z-10 bg-gradient-to-b from-black/80 to-transparent transition-opacity duration-300",
+				showOverlay ? "opacity-100" : "opacity-0 pointer-events-none"
+			)}
+		>
+			<div class="flex items-center justify-between px-4 py-3">
+				<div class="flex items-center gap-3">
+					<Button variant="ghost" size="icon" class="text-white hover:bg-white/10" onclick={goBack}>
+						<ArrowLeft class="h-5 w-5" />
+					</Button>
+					<div class="flex items-center gap-2">
+						<span class={cn(
+							"h-2.5 w-2.5 rounded-full",
+							camera.connected ? "bg-primary animate-pulse" : "bg-destructive"
+						)}></span>
+						<span class="text-sm font-medium text-white">{displayName}</span>
+						<span class={cn(
+							"text-[10px] uppercase tracking-wider font-semibold px-1.5 py-0.5 rounded",
+							camera.connected ? "bg-primary/20 text-primary" : "bg-destructive/20 text-destructive"
+						)}>
+							{camera.connected ? 'LIVE' : 'OFF'}
+						</span>
+					</div>
+				</div>
+				<div class="flex items-center gap-1">
+					{#if stats && stats.width > 0}
+						<span class="text-[10px] text-white/40 font-mono mr-2">
+							{stats.width}x{stats.height}
+							{#if stats.bitrateKbps > 0}
+								&middot; {formatBitrate(stats.bitrateKbps)}
+							{/if}
+						</span>
+					{/if}
+					<Button variant="ghost" size="icon" class="text-white hover:bg-white/10" onclick={captureSnapshot} title="Snapshot (S)">
+						<Camera class="h-4 w-4" />
+					</Button>
+					<Button variant="ghost" size="icon" class="text-white hover:bg-white/10" onclick={togglePiP} title="Picture-in-Picture (P)">
+						<PictureInPicture2 class="h-4 w-4" />
+					</Button>
+					<Button variant="ghost" size="icon" class="text-white hover:bg-white/10" onclick={() => (muted = !muted)} title="Mute (M)">
+						{#if muted}
+							<VolumeOff class="h-5 w-5" />
+						{:else}
+							<Volume2 class="h-5 w-5" />
+						{/if}
+					</Button>
+					<Button variant="ghost" size="icon" class="text-white hover:bg-white/10" onclick={toggleFullscreen} title="Fullscreen (F)">
+						{#if isFullscreen}
+							<Minimize class="h-5 w-5" />
+						{:else}
+							<Maximize class="h-5 w-5" />
+						{/if}
+					</Button>
+				</div>
+			</div>
+		</div>
+
+		<!-- Bottom overlay -->
+		<div
+			class={cn(
+				"absolute inset-x-0 bottom-0 z-10 bg-gradient-to-t from-black/80 to-transparent transition-opacity duration-300",
+				showOverlay ? "opacity-100" : "opacity-0 pointer-events-none"
+			)}
+		>
+			<div class="px-4 pb-3 pt-8">
+				<!-- Audio meter -->
+				<div class="mb-3">
+					<AudioMeter sourceId={cameraId} />
+				</div>
+				<!-- Telemetry row -->
+				{#if camera.telemetry}
+					<div class="flex items-center gap-4 text-xs text-white/70 font-mono">
+						<span>CPU {camera.telemetry.cpu_usage.toFixed(1)}%</span>
+						<span>MEM {camera.telemetry.memory_usage.toFixed(1)}%</span>
+						<span>Disk {camera.telemetry.disk_usage.toFixed(1)}%</span>
+						{#if camera.telemetry.cpu_temp !== null}
+							<span>{camera.telemetry.cpu_temp.toFixed(0)}&deg;C</span>
+						{/if}
+						<span>Up {formatUptime(camera.telemetry.uptime_secs)}</span>
+						{#if camera.telemetry.gps}
+							<span>GPS {camera.telemetry.gps.latitude.toFixed(4)}, {camera.telemetry.gps.longitude.toFixed(4)}</span>
+						{/if}
+					</div>
+				{/if}
+			</div>
+		</div>
+
+		<!-- Keyboard shortcut hint (fades out) -->
+		<div
+			class={cn(
+				"absolute bottom-4 right-4 z-10 text-[10px] text-white/30 transition-opacity duration-300",
+				showOverlay ? "opacity-100" : "opacity-0"
+			)}
+		>
+			F fullscreen &middot; M mute &middot; S snapshot &middot; P pip &middot; Esc back
+		</div>
+	</div>
+{:else}
+	<div class="flex h-full items-center justify-center text-muted-foreground">
+		Camera not found
+	</div>
+{/if}

--- a/ui/src/lib/views/DashboardView.svelte
+++ b/ui/src/lib/views/DashboardView.svelte
@@ -1,0 +1,264 @@
+<script lang="ts">
+	import { cameraStore } from '$lib/stores/cameras.svelte.js';
+	import { cameraConfigStore } from '$lib/stores/cameraConfig.svelte.js';
+	import { videoStatsStore } from '$lib/stores/videoStats.svelte.js';
+	import { transportStore } from '$lib/stores/transport.svelte.js';
+	import { alertsStore } from '$lib/stores/alerts.svelte.js';
+	import Sparkline from '$lib/components/ui/Sparkline.svelte';
+	import type { ServerStatus } from '$lib/types.js';
+	import { cn } from '$lib/utils.js';
+
+	let status = $state<ServerStatus | null>(null);
+
+	// Periodically fetch server status
+	$effect(() => {
+		function fetchStatus() {
+			transportStore.getTransport().getStatus()
+				.then((s) => (status = s))
+				.catch(() => {});
+		}
+		fetchStatus();
+		const interval = setInterval(fetchStatus, 5000);
+		return () => clearInterval(interval);
+	});
+
+	// Aggregate video stats across all cameras
+	let totalBitrate = $derived(() => {
+		let total = 0;
+		for (const cam of cameraStore.cameras) {
+			const stats = videoStatsStore.get(cam.id);
+			if (stats) total += stats.bitrateKbps;
+		}
+		return total;
+	});
+
+	let totalDropped = $derived(() => {
+		let total = 0;
+		for (const cam of cameraStore.cameras) {
+			const stats = videoStatsStore.get(cam.id);
+			if (stats) total += stats.droppedSegments;
+		}
+		return total;
+	});
+
+	// Track bitrate history for sparkline (last 60 samples at 2s intervals = 2 min)
+	let bitrateHistory = $state<number[]>([]);
+	$effect(() => {
+		const interval = setInterval(() => {
+			const current = totalBitrate();
+			bitrateHistory = [...bitrateHistory.slice(-59), current];
+		}, 2000);
+		return () => clearInterval(interval);
+	});
+
+	// Track frame history
+	let frameHistory = $state<number[]>([]);
+	let lastFrames = $state(0);
+	$effect(() => {
+		const interval = setInterval(() => {
+			if (status) {
+				const delta = status.frames_received - lastFrames;
+				lastFrames = status.frames_received;
+				if (delta >= 0) {
+					frameHistory = [...frameHistory.slice(-59), delta];
+				}
+			}
+		}, 2000);
+		return () => clearInterval(interval);
+	});
+
+	// Per-camera stats for the table
+	let cameraStats = $derived(() => {
+		return cameraStore.cameras.map((cam) => {
+			const stats = videoStatsStore.get(cam.id);
+			const displayName = cameraConfigStore.getDisplayName(cam.id, cam.name);
+			return {
+				id: cam.id,
+				name: displayName,
+				connected: cam.connected,
+				resolution: stats ? `${stats.width}x${stats.height}` : '-',
+				codec: stats?.codec ?? '-',
+				bitrate: stats?.bitrateKbps ?? 0,
+				dropped: stats?.droppedSegments ?? 0,
+				bufferHealth: stats?.bufferHealth ?? 0,
+				cpu: cam.telemetry?.cpu_usage ?? null,
+				memory: cam.telemetry?.memory_usage ?? null,
+				disk: cam.telemetry?.disk_usage ?? null,
+				temp: cam.telemetry?.cpu_temp ?? null,
+			};
+		});
+	});
+
+	function formatBitrate(kbps: number): string {
+		if (kbps >= 1000) return `${(kbps / 1000).toFixed(1)} Mbps`;
+		if (kbps > 0) return `${kbps.toFixed(0)} kbps`;
+		return '0 kbps';
+	}
+
+	function formatUptime(secs: number): string {
+		const d = Math.floor(secs / 86400);
+		const h = Math.floor((secs % 86400) / 3600);
+		const m = Math.floor((secs % 3600) / 60);
+		if (d > 0) return `${d}d ${h}h ${m}m`;
+		return `${h}h ${m}m`;
+	}
+</script>
+
+<div class="h-full overflow-auto p-4 space-y-4">
+	<!-- Top stats cards -->
+	<div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+		<!-- Cameras -->
+		<div class="rounded-lg border bg-card p-4">
+			<div class="text-xs text-muted-foreground font-medium">Cameras</div>
+			<div class="text-2xl font-bold mt-1">
+				{cameraStore.onlineCount}<span class="text-sm text-muted-foreground font-normal">/{cameraStore.cameras.length}</span>
+			</div>
+			<div class="text-[10px] text-muted-foreground mt-1">online</div>
+		</div>
+
+		<!-- Bandwidth -->
+		<div class="rounded-lg border bg-card p-4">
+			<div class="text-xs text-muted-foreground font-medium">Total Bandwidth</div>
+			<div class="text-2xl font-bold mt-1">{formatBitrate(totalBitrate())}</div>
+			<div class="mt-1">
+				<Sparkline data={bitrateHistory} color="hsl(var(--primary))" width={100} height={24} />
+			</div>
+		</div>
+
+		<!-- Frames -->
+		<div class="rounded-lg border bg-card p-4">
+			<div class="text-xs text-muted-foreground font-medium">Frames</div>
+			<div class="text-2xl font-bold mt-1">
+				{status?.frames_received?.toLocaleString() ?? '-'}
+			</div>
+			<div class="mt-1">
+				<Sparkline data={frameHistory} color="hsl(var(--primary))" width={100} height={24} />
+			</div>
+		</div>
+
+		<!-- Uptime -->
+		<div class="rounded-lg border bg-card p-4">
+			<div class="text-xs text-muted-foreground font-medium">Server Uptime</div>
+			<div class="text-2xl font-bold mt-1">{status ? formatUptime(status.uptime_secs) : '-'}</div>
+			<div class="text-[10px] text-muted-foreground mt-1">
+				{status?.clients ?? 0} client{(status?.clients ?? 0) !== 1 ? 's' : ''} connected
+			</div>
+		</div>
+	</div>
+
+	<!-- Connection & alerts overview -->
+	<div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+		<!-- Connection -->
+		<div class="rounded-lg border bg-card p-4">
+			<div class="text-xs text-muted-foreground font-medium mb-2">Connection</div>
+			<div class="flex items-center gap-2">
+				<span class={cn(
+					"h-2.5 w-2.5 rounded-full",
+					transportStore.connected ? "bg-primary animate-pulse" : "bg-destructive"
+				)}></span>
+				<span class="text-sm font-medium">
+					{transportStore.connected ? 'Connected' : 'Disconnected'}
+				</span>
+			</div>
+			{#if transportStore.error}
+				<p class="text-xs text-destructive mt-1">{transportStore.error}</p>
+			{/if}
+			{#if status?.public_key}
+				<div class="mt-2">
+					<span class="text-[10px] text-muted-foreground">Public Key</span>
+					<p class="font-mono text-[10px] break-all mt-0.5 text-muted-foreground">{status.public_key}</p>
+				</div>
+			{/if}
+		</div>
+
+		<!-- Dropped frames -->
+		<div class="rounded-lg border bg-card p-4">
+			<div class="text-xs text-muted-foreground font-medium mb-2">Stream Health</div>
+			<div class="space-y-1.5">
+				<div class="flex justify-between text-sm">
+					<span>Total Dropped</span>
+					<span class={cn("font-mono", totalDropped() > 0 ? "text-yellow-500" : "text-primary")}>{totalDropped()}</span>
+				</div>
+				<div class="flex justify-between text-sm">
+					<span>Frames Broadcast</span>
+					<span class="font-mono">{status?.frames_broadcast?.toLocaleString() ?? '-'}</span>
+				</div>
+			</div>
+		</div>
+
+		<!-- Alerts summary -->
+		<div class="rounded-lg border bg-card p-4">
+			<div class="text-xs text-muted-foreground font-medium mb-2">Alerts</div>
+			<div class="space-y-1.5">
+				<div class="flex justify-between text-sm">
+					<span>Unread</span>
+					<span class={cn("font-mono", alertsStore.unreadCount > 0 ? "text-destructive" : "")}>{alertsStore.unreadCount}</span>
+				</div>
+				<div class="flex justify-between text-sm">
+					<span>Total</span>
+					<span class="font-mono">{alertsStore.alerts.length}</span>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<!-- Per-camera table -->
+	<div class="rounded-lg border bg-card overflow-hidden">
+		<div class="px-4 py-3 border-b">
+			<h3 class="text-sm font-medium">Camera Details</h3>
+		</div>
+		<div class="overflow-x-auto">
+			<table class="w-full text-xs">
+				<thead>
+					<tr class="border-b text-muted-foreground">
+						<th class="text-left px-4 py-2 font-medium">Camera</th>
+						<th class="text-left px-3 py-2 font-medium">Status</th>
+						<th class="text-left px-3 py-2 font-medium">Resolution</th>
+						<th class="text-left px-3 py-2 font-medium">Codec</th>
+						<th class="text-right px-3 py-2 font-medium">Bitrate</th>
+						<th class="text-right px-3 py-2 font-medium">Buffer</th>
+						<th class="text-right px-3 py-2 font-medium">Dropped</th>
+						<th class="text-right px-3 py-2 font-medium">CPU</th>
+						<th class="text-right px-3 py-2 font-medium">Mem</th>
+						<th class="text-right px-3 py-2 font-medium">Disk</th>
+						<th class="text-right px-4 py-2 font-medium">Temp</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each cameraStats() as cam (cam.id)}
+						<tr class="border-b last:border-0 hover:bg-accent/30">
+							<td class="px-4 py-2 font-medium">{cam.name}</td>
+							<td class="px-3 py-2">
+								<span class={cn(
+									"inline-flex items-center gap-1",
+									cam.connected ? "text-primary" : "text-destructive"
+								)}>
+									<span class={cn("h-1.5 w-1.5 rounded-full", cam.connected ? "bg-primary" : "bg-destructive")}></span>
+									{cam.connected ? 'Online' : 'Offline'}
+								</span>
+							</td>
+							<td class="px-3 py-2 font-mono">{cam.resolution}</td>
+							<td class="px-3 py-2 font-mono">{cam.codec}</td>
+							<td class="px-3 py-2 text-right font-mono">{cam.bitrate > 0 ? formatBitrate(cam.bitrate) : '-'}</td>
+							<td class="px-3 py-2 text-right font-mono">{cam.bufferHealth > 0 ? `${cam.bufferHealth.toFixed(2)}s` : '-'}</td>
+							<td class="px-3 py-2 text-right font-mono">
+								<span class={cam.dropped > 0 ? "text-yellow-500" : ""}>{cam.dropped}</span>
+							</td>
+							<td class="px-3 py-2 text-right font-mono">{cam.cpu !== null ? `${cam.cpu.toFixed(0)}%` : '-'}</td>
+							<td class="px-3 py-2 text-right font-mono">{cam.memory !== null ? `${cam.memory.toFixed(0)}%` : '-'}</td>
+							<td class="px-3 py-2 text-right font-mono">{cam.disk !== null ? `${cam.disk.toFixed(0)}%` : '-'}</td>
+							<td class="px-4 py-2 text-right font-mono">{cam.temp !== null ? `${cam.temp.toFixed(0)}\u00B0C` : '-'}</td>
+						</tr>
+					{/each}
+					{#if cameraStats().length === 0}
+						<tr>
+							<td colspan="11" class="px-4 py-8 text-center text-muted-foreground">
+								No cameras connected
+							</td>
+						</tr>
+					{/if}
+				</tbody>
+			</table>
+		</div>
+	</div>
+</div>

--- a/ui/src/lib/views/DashboardView.svelte
+++ b/ui/src/lib/views/DashboardView.svelte
@@ -58,6 +58,10 @@
 	$effect(() => {
 		const interval = setInterval(() => {
 			if (status) {
+				if (lastFrames === 0) {
+					lastFrames = status.frames_received;
+					return;
+				}
 				const delta = status.frames_received - lastFrames;
 				lastFrames = status.frames_received;
 				if (delta >= 0) {

--- a/ui/src/lib/views/LiveView.svelte
+++ b/ui/src/lib/views/LiveView.svelte
@@ -8,7 +8,7 @@
 
 	let gridLayout = $derived(settingsStore.gridLayout);
 
-	let gridClass = $derived(() => {
+	let gridClass = $derived.by(() => {
 		switch (gridLayout) {
 			case '1+5':
 				return 'grid-cols-3';
@@ -18,7 +18,7 @@
 	});
 
 	// Apply group filter
-	let cameras = $derived(() => {
+	let cameras = $derived.by(() => {
 		const all = cameraStore.cameras;
 		if (!cameraConfigStore.activeGroupId) return all;
 		return all.filter(
@@ -27,8 +27,8 @@
 	});
 
 	// For 1+5 layout, put selected camera first so it gets the featured (large) slot
-	let sortedCameras = $derived(() => {
-		const cams = cameras();
+	let sortedCameras = $derived.by(() => {
+		const cams = cameras;
 		if (gridLayout !== '1+5' || !cameraStore.selectedId) return cams;
 		const selected = cams.find((c) => c.id === cameraStore.selectedId);
 		if (!selected) return cams;
@@ -39,8 +39,8 @@
 <div class="flex flex-col h-full overflow-hidden">
 	<!-- Video grid -->
 	<div class="flex-1 min-h-0 overflow-y-auto p-2">
-	<div class={cn("grid gap-3", gridClass())}>
-		{#each sortedCameras() as camera, i (camera.id)}
+	<div class={cn("grid gap-3", gridClass)}>
+		{#each sortedCameras as camera, i (camera.id)}
 			<CameraCard
 				sourceId={camera.id}
 				name={cameraConfigStore.getDisplayName(camera.id, camera.name)}
@@ -49,7 +49,7 @@
 			/>
 		{/each}
 
-		{#if cameras().length === 0}
+		{#if cameras.length === 0}
 			<div class="col-span-full flex items-center justify-center text-muted-foreground text-sm">
 				{#if cameraConfigStore.activeGroupId}
 					No cameras in this group

--- a/ui/src/lib/views/LiveView.svelte
+++ b/ui/src/lib/views/LiveView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { cameraStore } from '$lib/stores/cameras.svelte.js';
+	import { cameraConfigStore } from '$lib/stores/cameraConfig.svelte.js';
 	import { settingsStore } from '$lib/stores/settings.svelte.js';
 	import CameraCard from '$lib/components/camera/CameraCard.svelte';
 	import RecordingTimeline from '$lib/components/timeline/RecordingTimeline.svelte';
@@ -16,14 +17,22 @@
 		}
 	});
 
-	let cameras = $derived(cameraStore.cameras);
+	// Apply group filter
+	let cameras = $derived(() => {
+		const all = cameraStore.cameras;
+		if (!cameraConfigStore.activeGroupId) return all;
+		return all.filter(
+			(c) => cameraConfigStore.getGroupId(c.id) === cameraConfigStore.activeGroupId
+		);
+	});
 
 	// For 1+5 layout, put selected camera first so it gets the featured (large) slot
 	let sortedCameras = $derived(() => {
-		if (gridLayout !== '1+5' || !cameraStore.selectedId) return cameras;
-		const selected = cameras.find((c) => c.id === cameraStore.selectedId);
-		if (!selected) return cameras;
-		return [selected, ...cameras.filter((c) => c.id !== cameraStore.selectedId)];
+		const cams = cameras();
+		if (gridLayout !== '1+5' || !cameraStore.selectedId) return cams;
+		const selected = cams.find((c) => c.id === cameraStore.selectedId);
+		if (!selected) return cams;
+		return [selected, ...cams.filter((c) => c.id !== cameraStore.selectedId)];
 	});
 </script>
 
@@ -33,15 +42,19 @@
 		{#each sortedCameras() as camera, i (camera.id)}
 			<CameraCard
 				sourceId={camera.id}
-				name={camera.name}
+				name={cameraConfigStore.getDisplayName(camera.id, camera.name)}
 				connected={camera.connected}
 				featured={gridLayout === '1+5' && i === 0}
 			/>
 		{/each}
 
-		{#if cameras.length === 0}
+		{#if cameras().length === 0}
 			<div class="col-span-full flex items-center justify-center text-muted-foreground text-sm">
-				No cameras connected. Waiting for feeds...
+				{#if cameraConfigStore.activeGroupId}
+					No cameras in this group
+				{:else}
+					No cameras connected. Waiting for feeds...
+				{/if}
 			</div>
 		{/if}
 	</div>

--- a/ui/src/lib/views/LiveView.svelte
+++ b/ui/src/lib/views/LiveView.svelte
@@ -11,7 +11,7 @@
 	let gridClass = $derived(() => {
 		switch (gridLayout) {
 			case '1+5':
-				return 'grid-cols-3 grid-rows-2';
+				return 'grid-cols-3';
 			default: // auto
 				return 'grid-cols-[repeat(auto-fit,minmax(min(100%,28rem),1fr))]';
 		}
@@ -38,7 +38,8 @@
 
 <div class="flex flex-col h-full overflow-hidden">
 	<!-- Video grid -->
-	<div class={cn("flex-1 min-h-0 overflow-auto grid gap-2 p-2 content-start", gridClass())}>
+	<div class="flex-1 min-h-0 overflow-y-auto p-2">
+	<div class={cn("grid gap-3", gridClass())}>
 		{#each sortedCameras() as camera, i (camera.id)}
 			<CameraCard
 				sourceId={camera.id}
@@ -57,6 +58,7 @@
 				{/if}
 			</div>
 		{/if}
+	</div>
 	</div>
 
 	<!-- Recording timeline -->

--- a/ui/src/lib/views/__tests__/CameraView.test.ts
+++ b/ui/src/lib/views/__tests__/CameraView.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import CameraView from '../CameraView.svelte';
+import { cameraStore } from '$lib/stores/cameras.svelte.js';
+import { settingsStore } from '$lib/stores/settings.svelte.js';
+
+vi.mock('$lib/transport-ws.js', () => import('$lib/__mocks__/transport-ws.js'));
+
+// Mock browser APIs needed by child components
+(globalThis as any).MediaSource = class {
+  static isTypeSupported() { return false; }
+  readyState = 'closed';
+  addEventListener() {}
+  removeEventListener() {}
+  endOfStream() {}
+  addSourceBuffer() { return { addEventListener() {}, removeEventListener() {}, mode: '' }; }
+};
+(globalThis as any).AudioContext = class {
+  audioWorklet = { addModule: () => Promise.resolve() };
+  destination = {};
+  createGain() { return { connect: vi.fn(), disconnect: vi.fn(), gain: { value: 1 } }; }
+  close() { return Promise.resolve(); }
+};
+(globalThis as any).AudioWorkletNode = class {
+  port = { postMessage() {} };
+  connect() {}
+  disconnect() {}
+};
+
+import { resetMockTransport } from '$lib/__mocks__/transport-ws.js';
+
+describe('CameraView', () => {
+  beforeEach(() => {
+    resetMockTransport();
+    cameraStore.cameras = [
+      {
+        id: 'cam1', name: 'Front Door', connected: true,
+        telemetry: {
+          source_id: 'cam1', cpu_usage: 45, memory_usage: 62, disk_usage: 30,
+          uptime_secs: 3600, load_average: [1, 0.8, 0.6], cpu_temp: 55, gps: null, motion_level: null,
+        },
+      },
+      { id: 'cam2', name: 'Back Yard', connected: false },
+    ];
+    settingsStore.focusedCameraId = 'cam1';
+    settingsStore.currentView = 'camera' as any;
+  });
+
+  afterEach(() => {
+    resetMockTransport();
+    cameraStore.cameras = [];
+    cameraStore.selectedId = null;
+    settingsStore.focusedCameraId = null;
+    settingsStore.currentView = 'live' as any;
+  });
+
+  it('renders camera name and LIVE badge', async () => {
+    render(CameraView);
+    await tick();
+    expect(screen.getByText('Front Door')).toBeInTheDocument();
+    expect(screen.getByText('LIVE')).toBeInTheDocument();
+  });
+
+  it('shows OFF badge for disconnected camera', async () => {
+    settingsStore.focusedCameraId = 'cam2';
+    render(CameraView);
+    await tick();
+    expect(screen.getByText('Back Yard')).toBeInTheDocument();
+    expect(screen.getByText('OFF')).toBeInTheDocument();
+  });
+
+  it('contains a video element', async () => {
+    const { container } = render(CameraView);
+    await tick();
+    expect(container.querySelector('video')).toBeInTheDocument();
+  });
+
+  it('shows telemetry overlay when available', async () => {
+    render(CameraView);
+    await tick();
+    expect(screen.getByText(/CPU 45.0%/)).toBeInTheDocument();
+    expect(screen.getByText(/MEM 62.0%/)).toBeInTheDocument();
+    expect(screen.getByText(/55°C/)).toBeInTheDocument();
+  });
+
+  it('shows keyboard shortcut hints', async () => {
+    render(CameraView);
+    await tick();
+    expect(screen.getByText(/fullscreen/i)).toBeInTheDocument();
+    expect(screen.getByText(/mute/i)).toBeInTheDocument();
+    expect(screen.getByText(/back/i)).toBeInTheDocument();
+  });
+
+  it('shows "Camera not found" when no camera matches', async () => {
+    settingsStore.focusedCameraId = 'nonexistent';
+    render(CameraView);
+    await tick();
+    expect(screen.getByText('Camera not found')).toBeInTheDocument();
+  });
+
+  it('shows "Camera not found" when focusedCameraId is null', async () => {
+    settingsStore.focusedCameraId = null;
+    render(CameraView);
+    await tick();
+    expect(screen.getByText('Camera not found')).toBeInTheDocument();
+  });
+
+  it('renders uptime in telemetry overlay', async () => {
+    render(CameraView);
+    await tick();
+    expect(screen.getByText(/Up 1h 0m/)).toBeInTheDocument();
+  });
+});
+
+describe('settingsStore camera view', () => {
+  afterEach(() => {
+    settingsStore.focusedCameraId = null;
+    settingsStore.currentView = 'live' as any;
+  });
+
+  it('openCameraView sets view and camera id', () => {
+    settingsStore.openCameraView('cam1');
+    expect(settingsStore.currentView).toBe('camera');
+    expect(settingsStore.focusedCameraId).toBe('cam1');
+  });
+
+  it('closeCameraView returns to live view', () => {
+    settingsStore.openCameraView('cam1');
+    settingsStore.closeCameraView();
+    expect(settingsStore.currentView).toBe('live');
+    expect(settingsStore.focusedCameraId).toBeNull();
+  });
+
+  it('setView to non-camera clears focusedCameraId', () => {
+    settingsStore.openCameraView('cam1');
+    settingsStore.setView('map');
+    expect(settingsStore.focusedCameraId).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- **Fullscreen camera view** (#9): Double-click any camera for full-screen with keyboard shortcuts (F/M/S/P/Esc), audio meter, and telemetry HUD
- **Recording timeline & playback** (#10): Zoomable 1-24h timeline with play/pause, frame stepping, speed control (0.5-4x), and scrubbing
- **Alert system** (#11): Real-time alerts from telemetry thresholds (CPU/Mem/Temp/Motion), badge count, mark read/dismiss/clear all
- **Camera management** (#12): Rename cameras, create/edit/delete groups, filter by group chips, persistent config via localStorage
- **Camera card enhancements** (#13): Resolution/codec/bitrate overlay, snapshot/PiP/mute buttons, audio meter, dropped frame counter
- **Dashboard view** (#14): Server stats (cameras, bandwidth, frames, uptime), connection status, stream health, per-camera detail table with sparkline charts
- **Performance optimizations** (#15): Off-screen cameras skip segment processing, buffer cleanup, queue overflow handling, bitrate estimation
- **Video player error recovery**: 3-second sourceopen timeout with automatic retry, error handlers on video/MediaSource/SourceBuffer, centralized teardown
- **UI fixes**: Grid tile overlap, audio playback (deferred AudioContext for Chrome autoplay policy), auto-unmute on camera selection, dropped-frames badge positioning

## Test plan
- [x] `bun run check` — 0 errors, 1 warning (a11y autofocus)
- [x] `bun run test` — 178 tests passing
- [x] E2E tested with Chrome DevTools (mock data): all 10 test areas passed
- [x] E2E tested with real Kodama server + camera-sim (4 cameras): live video streaming, dashboard stats, map with GPS markers, disconnect/reconnect all verified
- [x] Verify video player recovery on page load with multiple cameras

🤖 Generated with [Claude Code](https://claude.com/claude-code)