### PR TITLE
Add Playwright e2e regression tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Type check
         run: cd ui && bun run check
 
+      - name: Unit tests
+        run: cd ui && bun run test
+
       - name: Build UI
         run: cd ui && bun run build
 
@@ -51,3 +54,30 @@ jobs:
 
       - name: Cargo check
         run: cargo check --workspace
+
+      - name: Cargo test
+        run: cargo test --workspace
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install UI dependencies
+        run: cd ui && bun install
+
+      - name: Install Playwright browsers
+        run: cd ui && bunx playwright install --with-deps chromium
+
+      - name: Run e2e tests
+        run: cd ui && bun run test:e2e
+
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: ui/test-results/

--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,8 @@ ui/build/
 **/bun.lock
 **/bun.lockb
 
+# Playwright
+ui/test-results/
+
 # Camera sim ephemeral keys
 .camera-keys/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/ui/e2e/app.test.ts
+++ b/ui/e2e/app.test.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test';
+import { setupMocks } from './helpers';
+
+test.beforeEach(async ({ page }) => {
+	await setupMocks(page);
+	await page.goto('/');
+});
+
+test.describe('App loads', () => {
+	test('shows header with KODAMA branding', async ({ page }) => {
+		await expect(page.getByText('KODAMA')).toBeVisible();
+	});
+
+	test('defaults to live view with empty state', async ({ page }) => {
+		await expect(page.getByText('Waiting for feeds')).toBeVisible();
+	});
+
+	test('shows 0 online in header', async ({ page }) => {
+		const header = page.getByRole('banner');
+		await expect(header.getByText('0', { exact: true })).toBeVisible();
+		await expect(header.getByText('online')).toBeVisible();
+	});
+});
+
+test.describe('View toggling', () => {
+	test('can switch between live and map views', async ({ page }) => {
+		// Default is live — empty state visible
+		await expect(page.getByText('Waiting for feeds')).toBeVisible();
+
+		// Switch to map
+		await page.getByRole('button', { name: /MAP/ }).click();
+		await expect(page.getByText('Waiting for feeds')).not.toBeVisible();
+
+		// Switch back to live
+		await page.getByRole('button', { name: /LIVE/ }).click();
+		await expect(page.getByText('Waiting for feeds')).toBeVisible();
+	});
+});
+
+test.describe('Settings dialog', () => {
+	test('opens and shows theme options', async ({ page }) => {
+		await page.locator('header').getByRole('button').last().click();
+
+		await expect(page.getByText('Settings')).toBeVisible();
+		await expect(page.getByRole('button', { name: /light/i })).toBeVisible();
+		await expect(page.getByRole('button', { name: /dark/i })).toBeVisible();
+		await expect(page.getByRole('button', { name: /system/i })).toBeVisible();
+	});
+
+	test('shows server status section', async ({ page }) => {
+		await page.locator('header').getByRole('button').last().click();
+
+		await expect(page.getByRole('heading', { name: 'Server Status' })).toBeVisible();
+	});
+
+	test('shows connection status', async ({ page }) => {
+		await page.locator('header').getByRole('button').last().click();
+
+		await expect(page.getByRole('heading', { name: 'Connection' })).toBeVisible();
+		// WebSocket mock accepts the upgrade, so transport reports connected
+		await expect(page.getByText('Connected', { exact: true })).toBeVisible();
+	});
+});
+
+test.describe('Header state', () => {
+	test('grid layout toggle visible in live view, marker toggle in map view', async ({ page }) => {
+		const header = page.getByRole('banner');
+		const toggleButtons = header.locator('button[aria-pressed]');
+
+		// Live view: view toggle (2) + grid layout (2) = 4 toggle buttons
+		await expect(toggleButtons).toHaveCount(4);
+
+		// Switch to map: view toggle (2) + marker mode (3) = 5 toggle buttons
+		await page.getByRole('button', { name: /MAP/ }).click();
+		await expect(toggleButtons).toHaveCount(5);
+	});
+});

--- a/ui/e2e/helpers.ts
+++ b/ui/e2e/helpers.ts
@@ -1,0 +1,37 @@
+import type { Page } from '@playwright/test';
+
+/** Intercept WebSocket so the transport connects without a real backend. */
+export async function mockWebSocket(page: Page) {
+	await page.routeWebSocket('**/ws', () => {
+		// Accept the upgrade but don't forward to a real server.
+		// The page sees a connected WebSocket that simply never sends data.
+	});
+}
+
+/** Mock REST API endpoints with realistic empty-state responses. */
+export async function mockApi(page: Page) {
+	await page.route('**/api/cameras', (route) =>
+		route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+	);
+
+	await page.route('**/api/status', (route) =>
+		route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				public_key: 'mock-public-key-abc123',
+				cameras: 0,
+				clients: 1,
+				uptime_secs: 120,
+				frames_received: 0,
+				frames_broadcast: 0,
+			}),
+		}),
+	);
+}
+
+/** Apply all mocks needed for a baseline page load. */
+export async function setupMocks(page: Page) {
+	await mockWebSocket(page);
+	await mockApi(page);
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "bits-ui": "^2.15.8",
@@ -22,6 +23,7 @@
     "tailwind-variants": "^0.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@sveltejs/vite-plugin-svelte": "^5",
     "@tailwindcss/vite": "^4",
     "@testing-library/dom": "^10.4.1",

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  retries: 0,
+  use: {
+    baseURL: 'http://localhost:5173',
+    headless: true,
+  },
+  projects: [
+    { name: 'chromium', use: { browserName: 'chromium' } },
+  ],
+  webServer: {
+    command: 'bun run dev',
+    port: 5173,
+    reuseExistingServer: !process.env.CI,
+  },
+});


### PR DESCRIPTION
## Summary
- Adds 8 Playwright e2e tests covering app load, view toggling, settings dialog, and header state
- Mocks WebSocket and REST APIs via Playwright route interception (no backend needed)
- Adds `e2e` CI job with Chromium-only browser tests and artifact upload on failure

## Test plan
- [x] `cd ui && bun run test:e2e` passes locally (8/8 tests)
- [x] CI workflow includes `e2e` job on `ubuntu-latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)